### PR TITLE
fix : #24 - build.gradle 위치 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
     // mapstruct
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
@@ -46,11 +50,10 @@ dependencies {
     // OAuth 2.0
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-    compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }


### PR DESCRIPTION
## 📌 목적
- mapStruct가 제대로 작동하지않는 버그

## 🛠️ 작업 상세 내용
정확한 원인분석은 찾지못함. 그래도 총 3개의 방법을 도입해봤음

- Gradle dependency 우선순위 문제 (https://develoyummer.tistory.com/55)
- 빌드 툴 Gradle이 아닌 IntelliJ IDEA 문제
- mapperImpl이 생성되지 않는 문제(https://velog.io/@dkvlg/mapstruct-%EC%98%A4%EB%A5%98-%EB%8B%A4-%EC%9E%A1%EA%B3%A0-%EB%8F%84%EC%9E%85-%EC%84%B1%EA%B3%B5)

## 🔍 해결 방법
build.gradle 의 lombok과 mapstruct의 위치를 바꾼다.
BuildTool을 Gradle -> IntelliJ로 바꾼다.
mapperImpl이 갱신되지 않는 경우 ./gradlew clean build -xtest 를 실행 후 다시 실행한다.
- Closes #24 