### PR TITLE
fix: #59 탈퇴한 회원 재가입 시 500 에러 해결

### DIFF
--- a/src/main/java/site/campingon/campingon/user/entity/Camp.java
+++ b/src/main/java/site/campingon/campingon/user/entity/Camp.java
@@ -1,5 +1,0 @@
-package site.campingon.campingon.user.entity;
-
-public class Camp {
-
-}

--- a/src/main/java/site/campingon/campingon/user/entity/User.java
+++ b/src/main/java/site/campingon/campingon/user/entity/User.java
@@ -14,6 +14,9 @@ import site.campingon.campingon.common.entity.BaseEntity;
 @NoArgsConstructor
 @Getter
 @Builder(toBuilder = true)
+@Table(uniqueConstraints = {
+    @UniqueConstraint(name = "up_email_deleted_at", columnNames = {"email", "deleted_at"})
+})
 public class User extends BaseEntity {
 
     @Id
@@ -21,7 +24,7 @@ public class User extends BaseEntity {
     @Column(columnDefinition = "INT UNSIGNED")
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Column(length = 60)

--- a/src/main/java/site/campingon/campingon/user/repository/UserRepository.java
+++ b/src/main/java/site/campingon/campingon/user/repository/UserRepository.java
@@ -2,8 +2,10 @@ package site.campingon.campingon.user.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import site.campingon.campingon.user.entity.User;
+import org.springframework.data.jpa.repository.Query;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -18,7 +20,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     User findByOauthName(String oauthName);
 
     // 이메일 또는 닉네임 중복 여부 확인
-    Optional<User> findByEmailOrNicknameAndDeletedAtIsNull(String email, String nickname);
+    @Query("SELECT u FROM User u WHERE (u.email = :email OR u.nickname = :nickname) AND u.deletedAt IS NULL")
+    Optional<User> findByEmailOrNicknameAndDeletedAtIsNull(@Param("email") String email, @Param("nickname") String nickname);
 
     // 닉네임 중복 확인
     boolean existsByNicknameAndDeletedAtIsNull(String nickname);


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

탈퇴한 회원 재가입 시 500 에러 해결

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] User Entity Unique 속성 변경
- [x] JPQL을 사용해 UserRepository 검색 부분 쿼리 직접 작성

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- User Entity email 컬럼 Unique 속성 제거
- User Entity email, deleted_at 묶어서 Unique 속성 부여

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트: Postman 이용
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #57 , #59 