### PR TITLE
Feat/#70 지역(시/도) 정보와 키워드를 바탕으로한 캠핑장 검색기능

### DIFF
--- a/src/main/java/site/campingon/campingon/bookmark/controller/BookMarkController.java
+++ b/src/main/java/site/campingon/campingon/bookmark/controller/BookMarkController.java
@@ -17,7 +17,7 @@ public class BookMarkController {
   private final BookmarkService bookmarkService;
 
   // 찜 기능 (토글활용)
-  @PostMapping("/{campId}/bookmarks")
+  @PatchMapping("/{campId}/bookmarks")
   public ResponseEntity<Void> bookmarkCamp(
       @PathVariable Long campId,
       @AuthenticationPrincipal UserDetails userDetails

--- a/src/main/java/site/campingon/campingon/camp/controller/CampController.java
+++ b/src/main/java/site/campingon/campingon/camp/controller/CampController.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import site.campingon.campingon.camp.dto.CampDetailResponseDto;
@@ -62,24 +63,21 @@ public class CampController {
     );
   }
 
-/*
   // TODO: NoSQL을 이용한 검색 기능 구현 & 엘라스틱 서치
   // 검색한 캠핑장 목록 (페이지네이션)
   @GetMapping("/search")
-  @PreAuthorize("isAuthenticated()")  // 로그인 확인
   public ResponseEntity<Page<CampListResponseDto>> searchCamps(
       @RequestParam String keyword,
       @RequestParam(required = false) String location,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size,
-      UserDto currentUser
+      @AuthenticationPrincipal UserDetails userDetails   // 사용자별 검색 기록 사용 시
   ) {
+    User user = (User) userDetails;
     PageRequest pageRequest = PageRequest.of(page, size);
-    Long userId = currentUser.getUserId();
-    Page<CampListResponseDto> camps = campService.searchCamps(keyword, location, pageRequest, userId);
+    Page<CampListResponseDto> camps = campService.searchCamps(keyword, location, pageRequest, user.getId());
     return ResponseEntity.ok(camps);
   }
-*/
 
   // 캠핑장 상세 조회  -  찜 버튼 활성화 시 유저 확인 추가
   @GetMapping("/{campId}")

--- a/src/main/java/site/campingon/campingon/camp/controller/CampController.java
+++ b/src/main/java/site/campingon/campingon/camp/controller/CampController.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import site.campingon.campingon.camp.dto.CampDetailResponseDto;
@@ -63,19 +62,22 @@ public class CampController {
     );
   }
 
-  // TODO: NoSQL을 이용한 검색 기능 구현 & 엘라스틱 서치
+  // TODO: NoSQL을 이용한 검색 기능 구현 & 엘라스틱 서치 | 인덱싱 작업
   // 검색한 캠핑장 목록 (페이지네이션)
   @GetMapping("/search")
   public ResponseEntity<Page<CampListResponseDto>> searchCamps(
       @RequestParam String keyword,
-      @RequestParam(required = false) String location,
+      @RequestParam(required = false) String city,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size,
-      @AuthenticationPrincipal UserDetails userDetails   // 사용자별 검색 기록 사용 시
+      //TODO: 사용자별 검색 기록 사용 시 필요(Redis - 서버사이드 캐시)
+      @AuthenticationPrincipal UserDetails userDetails
   ) {
     User user = (User) userDetails;
+    // searchHistoryService.saveSearchKeyword(user.getId(), keyword, city);
+
     PageRequest pageRequest = PageRequest.of(page, size);
-    Page<CampListResponseDto> camps = campService.searchCamps(keyword, location, pageRequest, user.getId());
+    Page<CampListResponseDto> camps = campService.searchCamps(user.getId(), keyword, city, pageRequest);
     return ResponseEntity.ok(camps);
   }
 

--- a/src/main/java/site/campingon/campingon/camp/repository/CampRepository.java
+++ b/src/main/java/site/campingon/campingon/camp/repository/CampRepository.java
@@ -1,7 +1,6 @@
 package site.campingon.campingon.camp.repository;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,7 +8,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import site.campingon.campingon.camp.entity.Camp;
 
-import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -33,6 +31,38 @@ public interface CampRepository extends JpaRepository<Camp, Long> {
   """)
   Page<Camp> findPopularCamps(Pageable pageable);
 
-  // 사용자의 isMarked 된 Camp
+  // 캠핑장명 검색
+  @Query("""
+    SELECT DISTINCT c FROM Camp c
+    LEFT JOIN c.campAddr ca
+    LEFT JOIN c.campInfo cr
+    WHERE (:city IS NULL OR ca.city = :city)
+    GROUP BY c
+    ORDER BY cr.recommendCnt DESC
+  """)
+  Page<Camp> findByCampNameSearch(String city, Pageable pageable);
+
+  // 캠핑 지역 확인 or 검색어와 일치하는 필드들(업종, 부대시설, 시군구, 캠핑장 키워드)의 캠핑장 목록 추천순으로 정렬
+  @Query("""
+    SELECT DISTINCT c FROM Camp c
+    LEFT JOIN c.campAddr ca
+    LEFT JOIN c.campInfo cr
+    LEFT JOIN c.keywords ck
+    WHERE (:city IS NULL OR ca.city = :city)
+    AND (:keyword IS NULL OR (
+        LOWER(c.induty) = :keyword
+        OR LOWER(c.outdoorFacility) = :keyword
+        OR LOWER(ca.state) = :keyword
+        OR LOWER(ck.keyword) = :keyword
+    ))
+    GROUP BY c
+    ORDER BY cr.recommendCnt DESC
+  """)
+  Page<Camp> searchCampsByKeywordAndCity(
+      @Param("keyword") String keyword, @Param("city") String city, Pageable pageable
+  );
+
+
+  // 사용자의 isMarked 된 캠핑장 목록 페이지
   Page<Camp> findByBookmarks_User_IdAndBookmarks_IsMarkedTrue(Long userId, Pageable pageable);
 }

--- a/src/main/java/site/campingon/campingon/camp/service/CampService.java
+++ b/src/main/java/site/campingon/campingon/camp/service/CampService.java
@@ -3,6 +3,7 @@ package site.campingon.campingon.camp.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -99,4 +100,9 @@ public class CampService {
 
     return new PageImpl<>(campDtos, pageable, bookmarkedCamps.getTotalElements());
   }
+
+  public Page<CampListResponseDto> searchCamps(String keyword, String location, PageRequest pageRequest, Long id) {
+
+  }
+
 }

--- a/src/main/java/site/campingon/campingon/camp/service/CampService.java
+++ b/src/main/java/site/campingon/campingon/camp/service/CampService.java
@@ -18,6 +18,7 @@ import site.campingon.campingon.camp.repository.CampSiteRepository;
 import site.campingon.campingon.bookmark.repository.BookmarkRepository;
 import site.campingon.campingon.user.repository.UserKeywordRepository;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,37 +37,27 @@ public class CampService {
   public Page<CampListResponseDto> getMatchedCampsByKeywords(Long userId, Pageable pageable) {
     List<String> userKeywords = userKeywordRepository.findKeywordsByUserId(userId);
 
+    // 사용자에 저장된 키워드가 없는 경우
     if (userKeywords.isEmpty()) {
       return Page.empty(pageable);
     }
 
-    // 키워드 매칭된 캠핑장을 페이지네이션으로 조회
-    Page<Camp> recommendedCamps = campRepository.findMatchedCampsByKeywords(userKeywords, pageable);
-
-    List<CampListResponseDto> campDtos = recommendedCamps.getContent().stream()
+    return campRepository.findMatchedCampsByKeywords(userKeywords, pageable)
         .map(camp -> {
           CampListResponseDto dto = campMapper.toCampListDto(camp);
           dto.setMarked(bookMarkRepository.existsByCampIdAndUserId(camp.getId(), userId));
           return dto;
-        })
-        .collect(Collectors.toList());
-
-    return new PageImpl<>(campDtos, pageable, recommendedCamps.getTotalElements());
+        });
   }
 
-  // 인기 캠핑장 조회 - recommendCnt에 따른
+  // 인기 캠핑장 조회
   public Page<CampListResponseDto> getPopularCamps(Long userId, Pageable pageable) {
-    Page<Camp> camps = campRepository.findPopularCamps(pageable);
-
-    List<CampListResponseDto> campDtos = camps.getContent().stream()
+    return campRepository.findPopularCamps(pageable)
         .map(camp -> {
           CampListResponseDto dto = campMapper.toCampListDto(camp);
           dto.setMarked(bookMarkRepository.existsByCampIdAndUserId(camp.getId(), userId));
           return dto;
-        })
-        .collect(Collectors.toList());
-
-    return new PageImpl<>(campDtos, pageable, camps.getTotalElements());
+        });
   }
 
   // 캠핑장 상세 조회
@@ -101,8 +92,40 @@ public class CampService {
     return new PageImpl<>(campDtos, pageable, bookmarkedCamps.getTotalElements());
   }
 
-  public Page<CampListResponseDto> searchCamps(String keyword, String location, PageRequest pageRequest, Long id) {
+  // 지역(시/도)과 검색어를 통한 캠핑장 목록 조회
+  public Page<CampListResponseDto> searchCamps(Long userId, String keyword, String city, PageRequest pageRequest) {
+    // 검색어를 소문자로 변환
+    String searchKeyword = keyword != null ? keyword.toLowerCase() : null;
 
+    // 먼저 캠핑장명으로 검색
+    List<CampListResponseDto> nameSearchResult = campRepository.findByCampNameSearch(city, pageRequest)
+        .getContent().stream()
+        .map(camp -> {
+          CampListResponseDto dto = campMapper.toCampListDto(camp);
+          dto.setMarked(bookMarkRepository.existsByCampIdAndUserId(camp.getId(), userId));
+          return dto;
+        })
+        .filter(dto -> {
+          if (searchKeyword == null) return true;
+          String campName = dto.getName().toLowerCase();
+          return campName.equals(searchKeyword)
+              || Arrays.asList(campName.split(" ")).contains(searchKeyword);
+        })
+        .collect(Collectors.toList());
+
+
+    // 캠핑장명 검색 결과가 없으면 키워드 검색
+    if (nameSearchResult.isEmpty()) {
+      // 지역 조건과 키워드 검색(업종, 부대시설, 시/군/구, 캠핑장 키워드)을 추천수로 페이지 정렬
+      return campRepository.searchCampsByKeywordAndCity(searchKeyword, city, pageRequest)
+          .map(camp -> {
+            CampListResponseDto dto = campMapper.toCampListDto(camp);
+            dto.setMarked(bookMarkRepository.existsByCampIdAndUserId(camp.getId(), userId));
+            return dto;
+          });
+    }
+
+    return new PageImpl<>(nameSearchResult, pageRequest, nameSearchResult.size());
   }
 
 


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

지역별 검색에 필요한 필드와 검색에 필요한 필드를 따로 묶어 단어 단위 일치 검색 기능 구현

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] CampAddr 엔티티의 필드 city로 선 필터링 작업
- [x] Camp 엔티티의 필드에 대한 검색 기능 구현
- [x] 최종 필터링된 캠핑장 목록을 추천수 순으로 정렬 

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- searchCamps 메서드에서 캠핑 지역과 검색어와 필드값 일치에 따른 검색이 이루어지며 추천순으로 정렬 조회 가능
- 캠핑장명과 다른 필드들(업종, 부대시설, 시군구, 캠핑장 키워드)을 나누어 캠핑장 목록 조회 
- 캠핑 지역 확인과 검색어 일치 검색이 이루어지며 모두 입력하지 않는 경우에는 모든 캠핑장의 추천수 순 정렬

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [ ] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #70 