### PR TITLE
Feat: #71 JWT Token LocalStorage에 저장하는 방식으로 변경

### DIFF
--- a/src/main/java/site/campingon/campingon/common/jwt/RefreshToken.java
+++ b/src/main/java/site/campingon/campingon/common/jwt/RefreshToken.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import site.campingon.campingon.common.entity.BaseEntity;
 
 @Entity
 @Getter
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Table(name = "refresh_token")
-public class RefreshToken {
+public class RefreshToken extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/campingon/campingon/common/jwt/RefreshTokenService.java
+++ b/src/main/java/site/campingon/campingon/common/jwt/RefreshTokenService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
+    @Transactional
     public void saveOrUpdateRefreshToken(String email, String refreshToken, long refreshTokenExpired) {
         refreshTokenRepository.findByEmail(email)
             .ifPresentOrElse(

--- a/src/main/java/site/campingon/campingon/user/service/UserAuthService.java
+++ b/src/main/java/site/campingon/campingon/user/service/UserAuthService.java
@@ -47,6 +47,7 @@ public class UserAuthService {
     }
 
     // 토큰 재발급
+    @Transactional
     public JwtToken refresh(String refreshToken) {
         log.info("Refresh Token을 사용한 Access Token 재발급");
         if (!jwtTokenProvider.validateToken(refreshToken)) {


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

오피스아워 때 받은 피드백 내용 적용.
기존에는 AccessToken은 localStorage와 Cookie에, RefreshToken은 Cookie에만 저장하는 방식을 사용했으나 프론트에서 서버로의 요청을 줄이기 위해 둘 다 local storage에 저장하는 방식으로 변경.

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] 토큰 발급 과정에서 `@Transactional` 어노테이션 추가
- [x] RefershToken에 생성일, 수정일 컬럼 추가
- [x] 로그인, 로그아웃, 토큰 재발급 과정에서 쿠키 저장 부분 제거

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- UserAuthController에서 쿠키 방식이 아닌 JWT token에 저장하는 방식으로 변경함.

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- XSS 공격을 막을 방법에 대해 찾아봐야 함.
- 프론트에서의 플로우
![JWT token drawio (1)](https://github.com/user-attachments/assets/9f249992-eb1b-4116-96c7-3fba2de7e273)
- 프론트(리액트) 코드
```js
/* axiosConfig.js */
// 요청 인터셉터
instance.interceptors.request.use(
    async (config) => {
        // 로그인 또는 비로그인 페이지 예외처리
        const nonAuthUrls = ["/login", "/register"]; // 인증 제외 경로
        if (nonAuthUrls.some((url) => config.url.includes(url))) {
            return config; // 토큰 검사 없이 요청 진행
        }
        
        const accessToken = localStorage.getItem("accessToken");

        // Access Token이 없는 경우 로그아웃 처리
        if (!accessToken) {
            alert("로그인이 필요합니다.");
            localStorage.clear();
            window.location.href = "/login";
            return Promise.reject("No access token");
        }

        // Access Token 만료 여부 확인
        if (isTokenExpired(accessToken)) {
            const refreshToken = localStorage.getItem("refreshToken");

            // Refresh Token이 없는 경우 로그아웃 처리
            if (!refreshToken || isTokenExpired(refreshToken)) {
                alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
                localStorage.clear();
                window.location.href = "/login";
                return Promise.reject("No valid refresh token");
            }

            // Refresh Token으로 Access Token 재발급 요청
            try {
                const response = await axios.post("http://localhost:8080/api/token/refresh", {
                    refreshToken,
                });

                const newAccessToken = response.data.accessToken;

                // 새 Access Token 저장
                localStorage.setItem("accessToken", newAccessToken);

                // Authorization 헤더에 새 Access Token 추가
                config.headers.Authorization = `Bearer ${newAccessToken}`;
            } catch (error) {
                console.error("Token refresh failed:", error);
                localStorage.clear();
                window.location.href = "/login";
                return Promise.reject(error);
            }
        } else {
            // Access Token이 유효한 경우 Authorization 헤더 설정
            config.headers.Authorization = `Bearer ${accessToken}`;
        }

        return config;
    },
    (error) => Promise.reject(error)
);
```
