### PR TITLE
Feat/#101 CampService 주요 메서드 별 실패 테스트, CampSite 목록 조회 테스트

### DIFF
--- a/src/main/java/site/campingon/campingon/camp/entity/CampSite.java
+++ b/src/main/java/site/campingon/campingon/camp/entity/CampSite.java
@@ -32,7 +32,7 @@ public class CampSite {
 
     @Column(length = 50, nullable = false)
     @Convert(converter = IndutyConverter.class) //converter 사용
-    private Induty type; // 업종 구분
+    private Induty siteType; // 업종 구분
 
     @Column(name = "indoor_facility", length = 255)
     private String indoorFacility;

--- a/src/main/java/site/campingon/campingon/common/public_data/service/GoCampingService.java
+++ b/src/main/java/site/campingon/campingon/common/public_data/service/GoCampingService.java
@@ -195,7 +195,7 @@ public class GoCampingService {
                     .camp(camp)
                     .maximumPeople(maximum_people)
                     .price(price)
-                    .type(induty)
+                    .siteType(induty)
                     .indoorFacility(innerFacility)
                     .build();
 

--- a/src/test/java/site/campingon/campingon/camp/service/CampSiteServiceTest.java
+++ b/src/test/java/site/campingon/campingon/camp/service/CampSiteServiceTest.java
@@ -1,0 +1,114 @@
+package site.campingon.campingon.camp.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.campingon.campingon.camp.dto.CampSiteListResponseDto;
+import site.campingon.campingon.camp.entity.Camp;
+import site.campingon.campingon.camp.entity.CampSite;
+import site.campingon.campingon.camp.entity.Induty;
+import site.campingon.campingon.camp.mapper.CampSiteMapper;
+import site.campingon.campingon.camp.repository.CampSiteRepository;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CampSiteServiceTest {
+
+  @Mock
+  private CampSiteRepository campSiteRepository;
+
+  @Mock
+  private CampSiteMapper campSiteMapper;
+
+  @InjectMocks
+  private CampSiteService campSiteService;
+
+  private Camp mockCamp;
+  private CampSite mockCampSite;
+  private CampSiteListResponseDto mockCampSiteListDto;
+
+  @BeforeEach
+  void setUp() {
+    mockCamp = Camp.builder()
+        .id(1L)
+        .campName("Test Camp")
+        .build();
+
+    mockCampSite = CampSite.builder()
+        .id(1L)
+        .camp(mockCamp)
+        .maximumPeople(4)
+        .price(50000)
+        .siteType(Induty.NORMAL_SITE)
+        .indoorFacility("화장실, 취사장")
+        .isAvailable(true)
+        .build();
+
+    mockCampSiteListDto = CampSiteListResponseDto.builder()
+        .siteId(1L)
+        .maxPeople(4)
+        .price(50000)
+        .indoor_facility("화장실, 취사장")
+        .type("일반야영장")
+        .checkInTime(LocalTime.of(15, 0))
+        .checkOutTime(LocalTime.of(11, 0))
+        .build();
+  }
+
+
+  @Test
+  @DisplayName("캠핑장의 캠핑지 전체 목록 조회 성공 확인 테스트")
+  void getCampInSites_success() {
+    // given
+    Long campId = 1L;
+    List<CampSite> campSites = Arrays.asList(mockCampSite);
+
+    when(campSiteRepository.findByCampId(campId)).thenReturn(campSites);
+    when(campSiteMapper.toCampSiteListDto(any(CampSite.class))).thenReturn(mockCampSiteListDto);
+
+    // when
+    List<CampSiteListResponseDto> result = campSiteService.getCampInSites(campId);
+
+    // then
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    assertEquals(mockCampSiteListDto, result.get(0));
+    assertEquals(mockCampSiteListDto.getSiteId(), result.get(0).getSiteId());
+    assertEquals(mockCampSiteListDto.getType(), result.get(0).getType());
+    assertEquals(mockCampSiteListDto.getMaxPeople(), result.get(0).getMaxPeople());
+
+    verify(campSiteRepository).findByCampId(campId);
+    verify(campSiteMapper).toCampSiteListDto(any(CampSite.class));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 캠핑장의 캠핑지 목록 조회 시 빈 리스트 반환 확인 테스트")
+  void getCampInSites_emptySites_returnsEmptyList() {
+    // given
+    Long nonExistentCampId = 999L;
+
+    when(campSiteRepository.findByCampId(nonExistentCampId)).thenReturn(Collections.emptyList());
+
+    // when
+    List<CampSiteListResponseDto> result = campSiteService.getCampInSites(nonExistentCampId);
+
+    // then
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+
+    verify(campSiteRepository).findByCampId(nonExistentCampId);
+    verify(campSiteMapper, never()).toCampSiteListDto(any(CampSite.class));
+  }
+}


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.
- 캠핑장 목록 조회에서 무조건 실패해야만 하는 경우를 테스트 경우를 통해 확인

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] 캠핑장 서비스 로직 관련 실패 경우의 단위 테스트
- [x] 캠핑지 서비스에서 캠핑장에 대한 캠핑지 테스트 + 실패 경우 테스트 추가

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- CampServiceTest 수정
- CampSiteServiceTest 작성
- CampSite엔티티의 Induty siteType로 변경 

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [x] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #101 