### PR TITLE
Feat: #102 JWT token 저장 방식 변경

### DIFF
--- a/src/main/java/site/campingon/campingon/common/jwt/CustomUserDetails.java
+++ b/src/main/java/site/campingon/campingon/common/jwt/CustomUserDetails.java
@@ -2,6 +2,7 @@ package site.campingon.campingon.common.jwt;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -9,7 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import site.campingon.campingon.user.entity.Role;
 
 @Getter
-public class CustomUserDetails implements UserDetails {
+public class CustomUserDetails implements UserDetails, CustomUserPrincipal {
     private final Long id;
     private final String email;
     private final String nickname;
@@ -24,12 +25,20 @@ public class CustomUserDetails implements UserDetails {
         this.password = password;
     }
 
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singletonList(new SimpleGrantedAuthority(role.name())); // 문자열 기반 권한
     }
 
+    @Override
+    public String getRole() {
+        return role.name();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Collections.emptyMap(); // OAuth2가 아니므로 빈 맵 반환
+    }
 
     @Override
     public String getPassword() {

--- a/src/main/java/site/campingon/campingon/common/jwt/CustomUserPrincipal.java
+++ b/src/main/java/site/campingon/campingon/common/jwt/CustomUserPrincipal.java
@@ -1,0 +1,11 @@
+package site.campingon.campingon.common.jwt;
+
+import java.util.Map;
+
+public interface CustomUserPrincipal {
+    String getEmail();
+    String getNickname();
+    String getRole();
+    Map<String, Object> getAttributes();
+
+}

--- a/src/main/java/site/campingon/campingon/common/oauth/CustomOAuth2User.java
+++ b/src/main/java/site/campingon/campingon/common/oauth/CustomOAuth2User.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import site.campingon.campingon.common.jwt.CustomUserPrincipal;
 import site.campingon.campingon.common.oauth.dto.OAuth2UserDto;
 
 import java.util.ArrayList;
@@ -12,7 +13,7 @@ import java.util.Map;
 
 @ToString
 @RequiredArgsConstructor
-public class CustomOAuth2User implements OAuth2User {
+public class CustomOAuth2User implements OAuth2User, CustomUserPrincipal {
 
     private final OAuth2UserDto OAuthUserDto;
     private final Map<String, Object> attributes;
@@ -44,11 +45,18 @@ public class CustomOAuth2User implements OAuth2User {
         return OAuthUserDto.getNickname();
     }
 
+    @Override
     public String getNickname() {
 
         return OAuthUserDto.getNickname();
     }
 
+    @Override
+    public String getRole() {
+        return OAuthUserDto.getRole();
+    }
+
+    @Override
     public String getEmail() {
 
         return OAuthUserDto.getEmail();

--- a/src/main/java/site/campingon/campingon/common/oauth/handler/CustomOAuthSuccessHandler.java
+++ b/src/main/java/site/campingon/campingon/common/oauth/handler/CustomOAuthSuccessHandler.java
@@ -1,6 +1,5 @@
 package site.campingon.campingon.common.oauth.handler;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +9,7 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 import site.campingon.campingon.common.jwt.JwtToken;
 import site.campingon.campingon.common.jwt.JwtTokenProvider;
+import site.campingon.campingon.common.jwt.RefreshTokenService;
 import site.campingon.campingon.common.util.CookieUtil;
 
 import java.io.IOException;
@@ -19,19 +19,27 @@ import java.io.IOException;
 public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    @Value("${app.front-url}")
+    private String frontUrl;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
         // JWT 토큰 생성
-        JwtToken jwtToken = jwtTokenProvider.generateOAuth2Token(authentication);
-
-        // Access Token을 쿠키에 추가
-        CookieUtil.setCookie(response, "accessToken", jwtToken.getAccessToken(), jwtTokenProvider.getAccessTokenExpired());
+        JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
+        String refreshToken = jwtToken.getRefreshToken();
+        String email = jwtTokenProvider.getEmailFromToken(refreshToken);
 
         // Refresh Token을 쿠키에 추가
-        CookieUtil.setCookie(response, "refreshToken", jwtToken.getRefreshToken(), jwtTokenProvider.getRefreshTokenExpired());
+        CookieUtil.setCookie(response, "refreshToken", refreshToken, jwtTokenProvider.getRefreshTokenExpired());
 
-        response.sendRedirect("/oauth/success");
+        // Refresh Token을 DB에 저장
+        refreshTokenService.saveOrUpdateRefreshToken(email, refreshToken, jwtTokenProvider.getRefreshTokenExpired());
+
+
+        String redirectUrl = frontUrl + "/oauth2/redirect";
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
     }
 }

--- a/src/main/java/site/campingon/campingon/user/dto/UserResponseDto.java
+++ b/src/main/java/site/campingon/campingon/user/dto/UserResponseDto.java
@@ -9,8 +9,8 @@ import site.campingon.campingon.user.entity.Role;
 @Builder
 public class UserResponseDto {
     private Long id;          // 사용자 ID
+    private String name;        // 사용자 이름
     private String email;     // 이메일
     private String nickname;  // 닉네임
     private Role role;      // 권한 (USER/ADMIN 등)
-    private boolean isDeleted; // 삭제 여부
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,6 +6,9 @@ spring:
           google:
             redirect-uri: http://localhost:8080/login/oauth2/code/google
 
+app:
+  front-url: http://localhost:3000
+
 jwt:
   access-expired: 300 # 5분
   refresh-expired: 7200 # 2시간


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

로그인 시 JWT  token 저장 방식을 변경하고 일반 유저와 OAuth 유저 모두에 적용

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] CustomOAuth2User와 CustomUserDetails를 한 번에 쓸 수 있도록 CustomUserPrincipal 인터페이스 생성
- [x] 기존 Local Storage 방식에서 Cookie에 refresh token 설정
- [x] 응답에 JWT token 담아 보내서 react 변수로 설정
- [x] application-dev에 프론트 url 추가
- [x] User 정보를 넘겨주는 UserResponseDto 내용 추가

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- application-dev에 프론트 url 추가
- User 정보를 넘겨주는 UserResponseDto 내용 추가
- 로그인 이후에 응답으로 Access Token 전송 및 `Set-Cookie`를 통해 쿠키에 refresh token 저장

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.
- OAuth 유저 로그 아웃시에도 CookieUtil의 deleteCookie를 통해서 쿠키(refresh token)을  초기화하고 DB에서 refresh token을 삭제 시켜줘야 합니다 @silverzoo 

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #102 