### PR TITLE
Feat/#116 캠핑장에서 예약 가능한 캠핑지 목록 조회 

### DIFF
--- a/src/main/java/site/campingon/campingon/camp/controller/CampSiteController.java
+++ b/src/main/java/site/campingon/campingon/camp/controller/CampSiteController.java
@@ -3,10 +3,7 @@ package site.campingon.campingon.camp.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import site.campingon.campingon.camp.dto.CampSiteListResponseDto;
 import site.campingon.campingon.camp.service.CampSiteService;
 
@@ -20,12 +17,12 @@ import java.util.List;
 public class CampSiteController {
   private final CampSiteService campSiteService;
 
-
   // 캠핑지 목록 조회
-  @GetMapping("/{campId}/sites")
-  public ResponseEntity<List<CampSiteListResponseDto>> getCampInSites(
-      @PathVariable("campId") Long campId
+  @GetMapping("/{campId}/available-sites")
+  public ResponseEntity<List<CampSiteListResponseDto>> getAvailableCampSites(
+      @PathVariable Long campId,
+      @RequestParam List<Long> reservedSiteIds
   ) {
-    return ResponseEntity.ok(campSiteService.getCampSites(campId));
+    return ResponseEntity.ok(campSiteService.getAvailableCampSites(campId, reservedSiteIds));
   }
 }

--- a/src/main/java/site/campingon/campingon/camp/entity/CampSite.java
+++ b/src/main/java/site/campingon/campingon/camp/entity/CampSite.java
@@ -1,10 +1,7 @@
 package site.campingon.campingon.camp.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import site.campingon.campingon.common.converter.IndutyConverter;
 
 @Entity

--- a/src/main/java/site/campingon/campingon/camp/service/CampSiteService.java
+++ b/src/main/java/site/campingon/campingon/camp/service/CampSiteService.java
@@ -63,11 +63,17 @@ public class CampSiteService {
                 .toList();
     }
 
-    // 캠핑장의 캠핑지 전체 목록 조회
-    public List<CampSiteListResponseDto> getCampInSites(Long campId) {
-        List<CampSite> campSites = campSiteRepository.findByCampId(campId);
+    // 캠핑장의 예약 가능한 SiteType별 캠핑지 조회
+    public List<CampSiteListResponseDto> getAvailableCampSites(Long campId, List<Long> reservedSiteIds) {
+        // 해당 캠핑장의 모든 캠프사이트 조회
+        List<CampSite> allCampSites = campSiteRepository.findByCampId(campId);
 
-        return campSites.stream()
+        // 예약 불가능한 사이트들 제외하고 타입별 그룹화
+        return allCampSites.stream()
+            .filter(site -> !reservedSiteIds.contains(site.getId()))  // 이미 예약된 사이트 제외
+            .collect(Collectors.groupingBy(CampSite::getSiteType)) // 그룹화
+            .values().stream()
+            .map(sites -> sites.get(0))  // 각 타입별 첫 번째 사이트만 선택
             .map(campSiteMapper::toCampSiteListDto)
             .collect(Collectors.toList());
     }

--- a/src/test/java/site/campingon/campingon/camp/service/CampSiteServiceTest.java
+++ b/src/test/java/site/campingon/campingon/camp/service/CampSiteServiceTest.java
@@ -67,48 +67,49 @@ class CampSiteServiceTest {
         .build();
   }
 
-
   @Test
-  @DisplayName("캠핑장의 캠핑지 전체 목록 조회 성공 확인 테스트")
-  void getCampInSites_success() {
+  @DisplayName("예약 가능한 캠프사이트 조회 성공 확인 테스트")
+  void getAvailableCampSites_success() {
     // given
     Long campId = 1L;
-    List<CampSite> campSites = Arrays.asList(mockCampSite);
+    List<Long> reservedSiteIds = Arrays.asList(2L, 3L);
+    List<CampSite> allCampSites = Arrays.asList(
+        mockCampSite,
+        CampSite.builder().id(2L).camp(mockCamp).siteType(Induty.NORMAL_SITE).build(),
+        CampSite.builder().id(3L).camp(mockCamp).siteType(Induty.CAR_SITE).build()
+    );
 
-    when(campSiteRepository.findByCampId(campId)).thenReturn(campSites);
+    when(campSiteRepository.findByCampId(campId)).thenReturn(allCampSites);
     when(campSiteMapper.toCampSiteListDto(any(CampSite.class))).thenReturn(mockCampSiteListDto);
 
     // when
-    List<CampSiteListResponseDto> result = campSiteService.getCampInSites(campId);
+    List<CampSiteListResponseDto> result = campSiteService.getAvailableCampSites(campId, reservedSiteIds);
 
     // then
     assertNotNull(result);
     assertEquals(1, result.size());
     assertEquals(mockCampSiteListDto, result.get(0));
-    assertEquals(mockCampSiteListDto.getSiteId(), result.get(0).getSiteId());
-    assertEquals(mockCampSiteListDto.getType(), result.get(0).getType());
-    assertEquals(mockCampSiteListDto.getMaxPeople(), result.get(0).getMaxPeople());
-
     verify(campSiteRepository).findByCampId(campId);
     verify(campSiteMapper).toCampSiteListDto(any(CampSite.class));
   }
 
   @Test
-  @DisplayName("존재하지 않는 캠핑장의 캠핑지 목록 조회 시 빈 리스트 반환 확인 테스트")
-  void getCampInSites_emptySites_returnsEmptyList() {
+  @DisplayName("모든 캠프사이트가 예약 불가능할 때 빈 리스트 반환 확인 테스트")
+  void getAvailableCampSites_allReserved_returnsEmptyList() {
     // given
-    Long nonExistentCampId = 999L;
+    Long campId = 1L;
+    List<Long> reservedSiteIds = Arrays.asList(1L);
+    List<CampSite> allCampSites = Arrays.asList(mockCampSite);
 
-    when(campSiteRepository.findByCampId(nonExistentCampId)).thenReturn(Collections.emptyList());
+    when(campSiteRepository.findByCampId(campId)).thenReturn(allCampSites);
 
     // when
-    List<CampSiteListResponseDto> result = campSiteService.getCampInSites(nonExistentCampId);
+    List<CampSiteListResponseDto> result = campSiteService.getAvailableCampSites(campId, reservedSiteIds);
 
     // then
     assertNotNull(result);
     assertTrue(result.isEmpty());
-
-    verify(campSiteRepository).findByCampId(nonExistentCampId);
+    verify(campSiteRepository).findByCampId(campId);
     verify(campSiteMapper, never()).toCampSiteListDto(any(CampSite.class));
   }
 }


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.
캠핑장 상세페이지의 예약 가능한 캠핑지들의 조회

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] CampSiteService에서 기존의 getCampInSites()에서 예약 도메인에서 넘어온 예약할 수 없는 camp_site_id 리스트들을 받아서 타입별로 하나씩만 예약 가능한 CampSite를 반환하도록 수정

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- 캠핑장에 대한 캠핑지 목록 조회에서 예약 가능한 타입별 캠핑지 조회로 변경 
- CampSiteServiceTest 코드 충돌 부분 해결 

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [x] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #116 