### PR TITLE
Feat/#130 리뷰 기능 구현 및 추천 토글 기능 추가

### DIFF
--- a/src/main/java/site/campingon/campingon/camp/controller/CampSiteController.java
+++ b/src/main/java/site/campingon/campingon/camp/controller/CampSiteController.java
@@ -25,4 +25,22 @@ public class CampSiteController {
   ) {
     return ResponseEntity.ok(campSiteService.getAvailableCampSites(campId, reservedSiteIds));
   }
+
+  // 특정 캠핑지의 isAvailable 상태를 토글
+  @PutMapping("/{campSiteId}/toggle-availability")
+  public ResponseEntity<Boolean> toggleAvailability(
+          @PathVariable Long campSiteId
+  ) {
+    boolean newAvailability = campSiteService.toggleAvailability(campSiteId);
+    return ResponseEntity.ok(newAvailability); // 변경된 isAvailable 상태 반환
+  }
+
+  // 특정 캠핑지의 isAvailable 상태 조회
+  @GetMapping("/{campSiteId}/availability")
+  public ResponseEntity<Boolean> getAvailability(
+          @PathVariable Long campSiteId
+  ) {
+    boolean isAvailable = campSiteService.getAvailability(campSiteId);
+    return ResponseEntity.ok(isAvailable); // 현재 isAvailable 상태 반환
+  }
 }

--- a/src/main/java/site/campingon/campingon/camp/entity/CampAddr.java
+++ b/src/main/java/site/campingon/campingon/camp/entity/CampAddr.java
@@ -17,11 +17,11 @@ public class CampAddr {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(columnDefinition = "INT UNSIGNED")
+    @Column(columnDefinition = "BIGINT UNSIGNED")
     private Long id;
 
     @OneToOne
-    @JoinColumn(name = "camp_id", nullable = false)
+    @JoinColumn(name = "camp_id", nullable = false, columnDefinition = "INT UNSIGNED")
     private Camp camp;
 
     @Column(length = 50)

--- a/src/main/java/site/campingon/campingon/camp/entity/CampImage.java
+++ b/src/main/java/site/campingon/campingon/camp/entity/CampImage.java
@@ -20,7 +20,7 @@ public class CampImage {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "camp_id", nullable = false)
+    @JoinColumn(name = "camp_id", nullable = false, columnDefinition = "INT UNSIGNED")
     private Camp camp;
 
     @Column(name = "image_url", length = 255, nullable = false)

--- a/src/main/java/site/campingon/campingon/camp/entity/CampInduty.java
+++ b/src/main/java/site/campingon/campingon/camp/entity/CampInduty.java
@@ -20,7 +20,7 @@ public class CampInduty {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "camp_id", nullable = false)
+    @JoinColumn(name = "camp_id", nullable = false, columnDefinition = "INT UNSIGNED")
     private Camp camp;
 
     @Column(nullable = false, length = 20)

--- a/src/main/java/site/campingon/campingon/camp/entity/CampInfo.java
+++ b/src/main/java/site/campingon/campingon/camp/entity/CampInfo.java
@@ -20,7 +20,7 @@ public class CampInfo {
     private Long id;
 
     @OneToOne
-    @JoinColumn(name = "camp_id", nullable = false)
+    @JoinColumn(name = "camp_id", nullable = false, columnDefinition = "INT UNSIGNED")
     private Camp camp;
 
     @Column(name = "recommend_cnt")

--- a/src/main/java/site/campingon/campingon/camp/entity/CampKeyword.java
+++ b/src/main/java/site/campingon/campingon/camp/entity/CampKeyword.java
@@ -20,7 +20,7 @@ public class CampKeyword {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "camp_id", nullable = false)
+    @JoinColumn(name = "camp_id", nullable = false, columnDefinition = "INT UNSIGNED")
     private Camp camp;
 
     @Column(length = 50, nullable = false)

--- a/src/main/java/site/campingon/campingon/camp/entity/CampSite.java
+++ b/src/main/java/site/campingon/campingon/camp/entity/CampSite.java
@@ -35,17 +35,6 @@ public class CampSite {
     private String indoorFacility;
 
     @Builder.Default
-    @Column(name = "is_available", nullable = false)
+    @Column(name = "is_available", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 1")
     private boolean isAvailable = false;
-//
-//    @PrePersist
-//    @PreUpdate
-//    private void setDefaultValues() {
-//        if (price == null) {
-//            this.price = siteType.getPrice();
-//        }
-//        if (maximumPeople == null) {
-//            this.maximumPeople = siteType.getMaximum_people();
-//        }
-//    }
 }

--- a/src/main/java/site/campingon/campingon/camp/service/CampSiteService.java
+++ b/src/main/java/site/campingon/campingon/camp/service/CampSiteService.java
@@ -87,4 +87,26 @@ public class CampSiteService {
                 .orElseThrow(() -> new RuntimeException("캠핑지를 찾을 수 없습니다."));
         return campSiteMapper.toCampSiteResponseDto(campSite);
     }
+
+    // isAvailable 상태를 토글하고 변경된 상태 반환
+    @Transactional
+    public boolean toggleAvailability(Long campSiteId) {
+        CampSite campSite = campSiteRepository.findById(campSiteId)
+                .orElseThrow(() -> new RuntimeException("캠프 사이트를 찾을 수 없습니다."));
+
+        boolean newAvailability = !campSite.isAvailable(); // 현재 상태를 반대로 변경
+        CampSite updatedCampSite = campSite.toBuilder()
+                .isAvailable(newAvailability) // 변경된 상태로 업데이트
+                .build();
+
+        campSiteRepository.save(updatedCampSite); // 저장
+        return newAvailability; // 변경된 상태 반환
+    }
+
+    // isAvailable 상태 조회
+    public boolean getAvailability(Long campSiteId) {
+        CampSite campSite = campSiteRepository.findById(campSiteId)
+                .orElseThrow(() -> new RuntimeException("캠프 사이트를 찾을 수 없습니다."));
+        return campSite.isAvailable();
+    }
 }

--- a/src/main/java/site/campingon/campingon/review/controller/ReviewController.java
+++ b/src/main/java/site/campingon/campingon/review/controller/ReviewController.java
@@ -1,0 +1,86 @@
+package site.campingon.campingon.review.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import site.campingon.campingon.review.dto.ReviewCreateRequestDto;
+import site.campingon.campingon.review.dto.ReviewResponseDto;
+import site.campingon.campingon.review.dto.ReviewUpdateRequestDto;
+import site.campingon.campingon.review.repository.ReviewRepository;
+import site.campingon.campingon.review.service.ReviewService;
+import site.campingon.campingon.user.entity.User;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/camps")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    // 리뷰 생성
+    @PostMapping(value = "/{campId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ReviewResponseDto> createReview(
+            @PathVariable("campId") Long campId,
+            @PathVariable("reservationId") Long reservationId,
+            @ModelAttribute ReviewCreateRequestDto requestDto
+    ) throws IOException {
+        return ResponseEntity.ok(reviewService.createReview(campId, reservationId, requestDto));
+    }
+
+
+    // 리뷰 수정
+    @PutMapping(value = "/{campId}/reviews/{reviewId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ReviewResponseDto> updateReview(
+            @PathVariable("campId") Long campId,
+            @PathVariable("reviewId") Long reviewId,
+            @ModelAttribute ReviewUpdateRequestDto requestDto
+    ) throws IOException {
+        return ResponseEntity.ok(reviewService.updateReview(campId, reviewId, requestDto));
+    }
+
+
+    // 캠핑장으로 리뷰 조회
+    @GetMapping("/camp/{campId}")
+    public ResponseEntity<List<ReviewResponseDto>> getReviewsByCampId(
+            @PathVariable("campId") Long campId
+    ) {
+        List<ReviewResponseDto> reviews = reviewService.getReviewsByCampId(campId);
+        return ResponseEntity.ok(reviews);
+    }
+
+    // 필요 없는거 같음
+    // 캠핑지로 리뷰 조회
+    @GetMapping("/campsite/{campSiteId}")
+    public ResponseEntity<List<ReviewResponseDto>> getReviewsByCampSiteId(
+            @PathVariable("campSiteId") Long campSiteId
+    ) {
+        List<ReviewResponseDto> reviews = reviewService.getReviewsByCampSiteId(campSiteId);
+        return ResponseEntity.ok(reviews);
+    }
+
+    // 리뷰 삭제
+    @DeleteMapping("/reviews/{reviewId}")
+    public ResponseEntity<Void> deleteReview(
+            @PathVariable("reviewId") Long reviewId
+    ) {
+        reviewService.deleteReview(reviewId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 리뷰 추천
+    @PatchMapping("/{reviewId}/recommend")
+    public ResponseEntity<Boolean> toggleRecommend(
+            @PathVariable("reviewId") Long reviewId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        User user = (User) userDetails;
+        boolean isRecommended = reviewService.toggleRecommend(reviewId, user.getId());
+        return ResponseEntity.ok(isRecommended);
+    }
+}

--- a/src/main/java/site/campingon/campingon/review/dto/CampDto.java
+++ b/src/main/java/site/campingon/campingon/review/dto/CampDto.java
@@ -1,5 +1,0 @@
-package site.campingon.campingon.review.dto;
-
-public class CampDto {
-
-}

--- a/src/main/java/site/campingon/campingon/review/dto/ReviewCreateRequestDto.java
+++ b/src/main/java/site/campingon/campingon/review/dto/ReviewCreateRequestDto.java
@@ -1,0 +1,20 @@
+package site.campingon.campingon.review.dto;
+
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewCreateRequestDto {
+    private Long campId; // 캠핑장 ID
+    private Long reservationId; // 예약 ID
+    private Long userId; // 작성자 ID
+    private String content; // 리뷰 내용
+    private boolean isRecommend; // 추천 여부
+    private List<MultipartFile> s3Images;
+}

--- a/src/main/java/site/campingon/campingon/review/dto/ReviewResponseDto.java
+++ b/src/main/java/site/campingon/campingon/review/dto/ReviewResponseDto.java
@@ -1,0 +1,20 @@
+package site.campingon.campingon.review.dto;
+
+import lombok.*;
+import site.campingon.campingon.review.entity.ReviewImage;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewResponseDto {
+    private Long reviewId;
+    private Long campId; // 캠핑장 ID
+    private Long reservationId; // 리뷰 ID
+    private Long userId; // 작성자 ID
+    private String content; // 리뷰 내용
+    private boolean isRecommend; // 추천 여부
+    private List<ReviewImage> images;
+}

--- a/src/main/java/site/campingon/campingon/review/dto/ReviewUpdateRequestDto.java
+++ b/src/main/java/site/campingon/campingon/review/dto/ReviewUpdateRequestDto.java
@@ -1,0 +1,20 @@
+package site.campingon.campingon.review.dto;
+
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewUpdateRequestDto {
+    private Long campId; // 캠핑장 ID
+    private Long reservationId; // 예약 ID
+    private Long userId; // 작성자 ID
+    private String content; // 리뷰 내용
+    private boolean isRecommend; // 추천 여부
+    private List<MultipartFile> s3Images;
+}

--- a/src/main/java/site/campingon/campingon/review/entity/Review.java
+++ b/src/main/java/site/campingon/campingon/review/entity/Review.java
@@ -1,0 +1,53 @@
+package site.campingon.campingon.review.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import site.campingon.campingon.camp.entity.Camp;
+import site.campingon.campingon.camp.entity.CampSite;
+import site.campingon.campingon.reservation.entity.Reservation;
+import site.campingon.campingon.user.entity.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ToString
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "review")
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, columnDefinition = "INT UNSIGNED")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "camp_id", nullable = false, columnDefinition = "INT UNSIGNED")
+    private Camp camp;
+
+    @ManyToOne
+    @JoinColumn(name = "camp_site_id", nullable = false, columnDefinition = "INT UNSIGNED")
+    private CampSite campSite;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false, columnDefinition = "INT UNSIGNED")
+    private Reservation reservation;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Builder.Default
+    @Column(name = "is_recommend", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 1")
+    private boolean isRecommend = false;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewImage> reviewImages = new ArrayList<>();
+}

--- a/src/main/java/site/campingon/campingon/review/entity/ReviewImage.java
+++ b/src/main/java/site/campingon/campingon/review/entity/ReviewImage.java
@@ -1,0 +1,28 @@
+package site.campingon.campingon.review.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "review_image")
+public class ReviewImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id; // 리뷰 이미지 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false, columnDefinition = "INT UNSIGNED")
+    private Review review; // 리뷰 ID
+
+    @Column(name = "image_url", length = 255)
+    private String imageUrl; // 이미지 URL
+}

--- a/src/main/java/site/campingon/campingon/review/mapper/ReviewImageMapper.java
+++ b/src/main/java/site/campingon/campingon/review/mapper/ReviewImageMapper.java
@@ -1,0 +1,50 @@
+package site.campingon.campingon.review.mapper;
+
+import org.mapstruct.*;
+import site.campingon.campingon.review.entity.Review;
+import site.campingon.campingon.review.entity.ReviewImage;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ReviewImageMapper {
+
+    // 리뷰 생성 매퍼
+    default ReviewImage toReviewImage(String url, Review review) {
+        if (url == null || review == null) {
+            throw new IllegalArgumentException("url 또는 review가 null일 수 없습니다.");
+        }
+
+        // 빌더 패턴 사용
+        return ReviewImage.builder()
+                .imageUrl(url)  // URL 설정
+                .review(review) // Review 설정
+                .build();
+    }
+
+    default List<ReviewImage> toEntityList(List<String> uploadedUrls, Review review) {
+        if (uploadedUrls == null || uploadedUrls.isEmpty()) {
+            return Collections.emptyList(); // URL이 비어 있으면 빈 리스트 반환
+        }
+        return uploadedUrls.stream()
+                .map(url -> toReviewImage(url, review)) // 각 URL을 ReviewImage로 변환
+                .collect(Collectors.toList()); // 리스트로 수집
+    }
+
+    // 리뷰 이미지 수정 매퍼
+    // 커스텀 메서드로 리스트 매핑
+    @Mapping(target = "review", source = "review")
+    @Mapping(target = "imageUrl", source = "url")
+    ReviewImage toEntity(Review review, String url);
+
+    // List 매핑
+    @Named("toEntities")
+    default List<ReviewImage> toEntities(Review review, List<String> uploadedUrls) {
+        return uploadedUrls.stream()
+                .map(url -> toEntity(review, url)) // 개별 매핑 메서드 호출
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/site/campingon/campingon/review/mapper/ReviewMapper.java
+++ b/src/main/java/site/campingon/campingon/review/mapper/ReviewMapper.java
@@ -1,0 +1,32 @@
+package site.campingon.campingon.review.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import site.campingon.campingon.camp.entity.Camp;
+import site.campingon.campingon.reservation.entity.Reservation;
+import site.campingon.campingon.review.dto.ReviewCreateRequestDto;
+import site.campingon.campingon.review.dto.ReviewResponseDto;
+import site.campingon.campingon.review.dto.ReviewUpdateRequestDto;
+import site.campingon.campingon.review.entity.Review;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ReviewMapper {
+
+    // 리뷰 생성 매퍼
+    @Mapping(target = "id", ignore = true)
+    Review toEntity(ReviewCreateRequestDto requestDto, Camp camp, Reservation reservation);
+
+    ReviewResponseDto toResponseDto(Review review);
+
+    // 리뷰 수정 매퍼
+    @Mapping(target = "content", source = "requestDto.content", defaultValue = "review.content")
+    Review updateFromRequest(Review review, ReviewUpdateRequestDto requestDto);
+
+    List<ReviewResponseDto> toResponseDtoList(List<Review> reviews);
+
+    @Mapping(target = "isRecommend", expression = "java(!review.isRecommend())")
+    Review toUpdatedReview(Review review);
+}

--- a/src/main/java/site/campingon/campingon/review/repository/ReviewImageRepository.java
+++ b/src/main/java/site/campingon/campingon/review/repository/ReviewImageRepository.java
@@ -1,0 +1,13 @@
+package site.campingon.campingon.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.campingon.campingon.review.entity.Review;
+import site.campingon.campingon.review.entity.ReviewImage;
+
+import java.util.List;
+
+@Repository
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+    List<ReviewImage> findByReview(Review review);
+}

--- a/src/main/java/site/campingon/campingon/review/repository/ReviewRepository.java
+++ b/src/main/java/site/campingon/campingon/review/repository/ReviewRepository.java
@@ -1,0 +1,29 @@
+package site.campingon.campingon.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import site.campingon.campingon.review.entity.Review;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    // 리뷰 상세 조회
+    Optional<Review> findById(Long id);
+
+    // 특정 캠핑지의 리뷰 조회
+    List<Review> findByCampSiteId(Long campSiteId);
+
+    // 특정 캠핑장 하위 모든 리뷰 조회
+    @Query("""
+            SELECT r FROM Review r
+            WHERE r.camp.id = :campId
+            """)
+    List<Review> findByCampId(@Param("campId") Long campId);
+
+    boolean existsByReservationId(Long reservationId);
+}

--- a/src/main/java/site/campingon/campingon/review/service/ReviewService.java
+++ b/src/main/java/site/campingon/campingon/review/service/ReviewService.java
@@ -1,0 +1,196 @@
+package site.campingon.campingon.review.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import site.campingon.campingon.camp.entity.Camp;
+import site.campingon.campingon.camp.entity.CampSite;
+import site.campingon.campingon.camp.repository.CampRepository;
+import site.campingon.campingon.camp.repository.CampSiteRepository;
+import site.campingon.campingon.reservation.entity.Reservation;
+import site.campingon.campingon.reservation.repository.ReservationRepository;
+import site.campingon.campingon.review.dto.ReviewCreateRequestDto;
+import site.campingon.campingon.review.dto.ReviewResponseDto;
+import site.campingon.campingon.review.dto.ReviewUpdateRequestDto;
+import site.campingon.campingon.review.entity.Review;
+import site.campingon.campingon.review.entity.ReviewImage;
+import site.campingon.campingon.review.mapper.ReviewImageMapper;
+import site.campingon.campingon.review.mapper.ReviewMapper;
+import site.campingon.campingon.review.repository.ReviewImageRepository;
+import site.campingon.campingon.review.repository.ReviewRepository;
+import site.campingon.campingon.s3bucket.service.S3BucketService;
+import site.campingon.campingon.user.repository.UserRepository;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewImageRepository reviewImageRepository;
+    private final ReservationRepository reservationRepository;
+    private final CampRepository campRepository;
+    private final CampSiteRepository campSiteRepository;
+    private final ReviewMapper reviewMapper;
+    private final ReviewImageMapper reviewImageMapper;
+    private final S3BucketService s3BucketService;
+    private final UserRepository userRepository;
+
+
+    // 리뷰 생성
+    @Transactional
+    public ReviewResponseDto createReview(
+            Long campId,
+            Long reservationId,
+            ReviewCreateRequestDto requestDto
+    ) throws IOException {
+        Camp camp = campRepository.findById(campId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 캠프장 ID입니다."));
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 예약 ID입니다."));
+
+        // 3. ReviewCreateRequestDto를 Review 엔티티로 변환하고 저장
+        Review review = reviewMapper.toEntity(requestDto, camp, reservation);
+        Review savedReview = reviewRepository.save(review);
+
+        List<String> uploadedUrls = s3BucketService.upload(requestDto.getS3Images(), "reviews/" + savedReview.getId());
+
+        // 5. 업로드된 URL 리스트와 저장된 리뷰 데이터를 사용하여 ReviewImage 엔티티 리스트 생성
+        List<ReviewImage> reviewImages = reviewImageMapper.toEntityList(uploadedUrls, savedReview);
+        reviewImageRepository.saveAll(reviewImages);
+
+        // 7. 저장된 Review 엔티티를 ReviewResponseDto로 변환하여 반환
+        return reviewMapper.toResponseDto(savedReview);
+    }
+      // 추후 단건 예약에 대해 중복 리뷰 작성 불가 로직 추가 예정
+//    // 예약이 완료된 상태를 기준으로 리뷰 작성
+//    @Transactional
+//    public ReviewResponseDto createReview(Long reservationId, ReviewCreateRequestDto requestDto) throws IOException {
+//        // 1. 예약 정보 가져오기
+//        Reservation reservation = reservationRepository.findById(reservationId)
+//                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 예약 ID입니다."));
+//
+//        // 2. 예약 상태 확인
+//        if (reservation.getStatus() != ReservationStatus.COMPLETED) {
+//            throw new IllegalArgumentException("완료된 예약에 대해서만 리뷰를 작성할 수 있습니다.");
+//        }
+//
+//        // 3. 기존 리뷰 여부 확인
+//        boolean hasReview = reviewRepository.existsByReservationId(reservationId);
+//        if (hasReview) {
+//            throw new IllegalArgumentException("이미 이 예약에 대해 리뷰를 작성하셨습니다.");
+//        }
+//
+//        // 4. 캠핑지 정보 가져오기
+//        CampSite campSite = reservation.getCampSite();
+//
+//        // 5. 리뷰 생성
+//        Review review = reviewMapper.toEntity(requestDto, camp, reservation);
+//        Review savedReview = reviewRepository.save(review);
+//
+//        // 6. 이미지 업로드
+//        List<String> uploadedUrls = s3BucketService.upload(requestDto.getS3Images(), "reviews/" + savedReview.getId());
+//        List<ReviewImage> reviewImages = reviewImageMapper.toEntityList(uploadedUrls, savedReview);
+//        reviewImageRepository.saveAll(reviewImages);
+//
+//        // 7. 응답 DTO 반환
+//        return reviewMapper.toResponseDto(savedReview);
+//    }
+
+
+    // 리뷰 수정
+    @Transactional
+    public ReviewResponseDto updateReview(Long campId, Long reviewId, ReviewUpdateRequestDto requestDto) throws IOException {
+        // 1. 기존 리뷰 조회
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 리뷰 ID입니다."));
+
+        // 2. 캠프 ID 확인
+        if (!review.getCamp().getId().equals(campId)) {
+            throw new IllegalArgumentException("리뷰가 해당 캠프에 속하지 않습니다.");
+        }
+
+        Review updatedReview = reviewMapper.updateFromRequest(review, requestDto);
+
+        // 4. 이미지 업데이트
+        List<MultipartFile> newImages = requestDto.getS3Images();
+        if (newImages != null && !newImages.isEmpty()) {
+            updateReviewImages(review, newImages);
+        }
+
+        // 5. 리뷰 저장
+        reviewRepository.save(review);
+
+        // 6. 응답 DTO 반환
+        return reviewMapper.toResponseDto(review);
+    }
+
+    private void updateReviewImages(Review review, List<MultipartFile> newImages) throws IOException {
+        // 1. 기존 이미지 삭제
+        List<ReviewImage> existingImages = reviewImageRepository.findByReview(review);
+        for (ReviewImage existingImage : existingImages) {
+            s3BucketService.remove(existingImage.getImageUrl());
+        }
+        reviewImageRepository.deleteAll(existingImages);
+
+        // 2. 새로운 이미지 업로드
+        List<String> uploadedUrls = s3BucketService.upload(newImages, "reviews/" + review.getId());
+
+        // 3. 새로운 이미지 엔티티 생성 및 저장
+        List<ReviewImage> newImageEntities = reviewImageMapper.toEntities(review, uploadedUrls);
+        reviewImageRepository.saveAll(newImageEntities);
+    }
+
+    // 리뷰 삭제
+    @Transactional
+    public void deleteReview(Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("Review not found with id: " + reviewId));
+
+        List<ReviewImage> reviewImages = reviewImageRepository.findByReview(review);
+        if (!reviewImages.isEmpty()) {
+            reviewImageRepository.deleteAll(reviewImages);
+            reviewImages.forEach(image -> s3BucketService.remove(image.getImageUrl()));
+        }
+
+        reviewRepository.delete(review);
+    }
+
+    // 캠핑장 id로 리뷰 조회
+    public List<ReviewResponseDto> getReviewsByCampId(Long campId) {
+        Camp camp = campRepository.findById(campId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 캠프장 ID입니다."));
+
+        List<Review> reviews = reviewRepository.findByCampId(camp.getId());
+        return reviewMapper.toResponseDtoList(reviews);
+    }
+
+    // 캠핑지 id로 리뷰 조회
+    public List<ReviewResponseDto> getReviewsByCampSiteId(Long campSiteId) {
+        CampSite campSite = campSiteRepository.findById(campSiteId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 캠핑지 ID입니다."));
+
+        List<Review> reviews = reviewRepository.findByCampSiteId(campSite.getId());
+        return reviewMapper.toResponseDtoList(reviews);
+    }
+
+    // 리뷰 추천 토글
+    public boolean toggleRecommend(Long reviewId, Long userId) {
+        // 리뷰 가져오기
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new EntityNotFoundException("Review not found with ID: " + reviewId));
+
+        // 작성자 확인
+        if (!review.getReservation().getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException("User is not authorized to toggle recommend for this review.");
+        }
+        Review updatedReview = reviewMapper.toUpdatedReview(review);
+        reviewRepository.save(updatedReview);
+        return updatedReview.isRecommend();
+    }
+}

--- a/src/test/java/site/campingon/campingon/camp/service/CampSiteServiceTest.java
+++ b/src/test/java/site/campingon/campingon/camp/service/CampSiteServiceTest.java
@@ -75,7 +75,7 @@ class CampSiteServiceTest {
   }
 
   @Test
-  @DisplayName("예약 가능한 캠프사이트 조회 성공 확인 테스트")
+  @DisplayName("TEST - 예약 가능한 캠프사이트 조회 성공 확인 테스트")
   void getAvailableCampSites_success() {
     // given
     Long campId = 1L;
@@ -101,7 +101,7 @@ class CampSiteServiceTest {
   }
 
   @Test
-  @DisplayName("모든 캠프사이트가 예약 불가능할 때 빈 리스트 반환 확인 테스트")
+  @DisplayName("TEST - 모든 캠프사이트가 예약 불가능할 때 빈 리스트 반환 확인 테스트")
   void getAvailableCampSites_allReserved_returnsEmptyList() {
     // given
     Long campId = 1L;
@@ -331,5 +331,59 @@ class CampSiteServiceTest {
     assertNotNull(responseDto);
     assertEquals(siteId, responseDto.getSiteId());
     verify(campSiteRepository, times(1)).findByIdAndCampId(siteId, campId);
+  }
+
+  @Test
+  @DisplayName("TEST - 캠프사이트 예약 가능 여부 토글")
+  public void testToggleAvailability() {
+    // Given
+    Long campSiteId = 1L;
+    CampSite existingCampSite = CampSite.builder()
+            .id(campSiteId)
+            .maximumPeople(10)
+            .price(10000)
+            .siteType(Induty.CAR_SITE)
+            .indoorFacility("Indoor Facility")
+            .isAvailable(false) // 초기 상태 false
+            .build();
+
+    CampSite updatedCampSite = existingCampSite.toBuilder()
+            .isAvailable(true) // 상태를 true로 변경
+            .build();
+
+    when(campSiteRepository.findById(campSiteId)).thenReturn(Optional.of(existingCampSite));
+    when(campSiteRepository.save(any(CampSite.class))).thenReturn(updatedCampSite);
+
+    // When
+    boolean updatedStatus = campSiteService.toggleAvailability(campSiteId);
+
+    // Then
+    assertTrue(updatedStatus);
+    verify(campSiteRepository, times(1)).findById(campSiteId);
+    verify(campSiteRepository, times(1)).save(any(CampSite.class));
+  }
+
+  @Test
+  @DisplayName("TEST - 캠프사이트 예약 가능 여부 조회")
+  public void testGetAvailability() {
+    // Given
+    Long campSiteId = 1L;
+    CampSite campSite = CampSite.builder()
+            .id(campSiteId)
+            .maximumPeople(10)
+            .price(10000)
+            .siteType(Induty.CAR_SITE)
+            .indoorFacility("Indoor Facility")
+            .isAvailable(true) // 초기 상태 true
+            .build();
+
+    when(campSiteRepository.findById(campSiteId)).thenReturn(Optional.of(campSite));
+
+    // When
+    boolean isAvailable = campSiteService.getAvailability(campSiteId);
+
+    // Then
+    assertTrue(isAvailable);
+    verify(campSiteRepository, times(1)).findById(campSiteId);
   }
 }

--- a/src/test/java/site/campingon/campingon/review/service/ReviewServiceTest.java
+++ b/src/test/java/site/campingon/campingon/review/service/ReviewServiceTest.java
@@ -1,0 +1,390 @@
+package site.campingon.campingon.review.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import site.campingon.campingon.camp.entity.Camp;
+import site.campingon.campingon.camp.entity.CampSite;
+import site.campingon.campingon.camp.repository.CampRepository;
+import site.campingon.campingon.reservation.entity.Reservation;
+import site.campingon.campingon.reservation.entity.ReservationStatus;
+import site.campingon.campingon.reservation.repository.ReservationRepository;
+import site.campingon.campingon.review.dto.ReviewCreateRequestDto;
+import site.campingon.campingon.review.dto.ReviewResponseDto;
+import site.campingon.campingon.review.dto.ReviewUpdateRequestDto;
+import site.campingon.campingon.review.entity.Review;
+import site.campingon.campingon.review.entity.ReviewImage;
+import site.campingon.campingon.review.mapper.ReviewImageMapper;
+import site.campingon.campingon.review.mapper.ReviewMapper;
+import site.campingon.campingon.review.repository.ReviewImageRepository;
+import site.campingon.campingon.review.repository.ReviewRepository;
+import site.campingon.campingon.s3bucket.service.S3BucketService;
+import site.campingon.campingon.user.entity.User;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static site.campingon.campingon.camp.entity.Induty.CAR_SITE;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @Mock
+    private CampRepository campRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private ReviewImageRepository reviewImageRepository;
+
+    @Mock
+    private S3BucketService s3BucketService;
+
+    @Mock
+    private ReviewMapper reviewMapper;
+
+    @Mock
+    private ReviewImageMapper reviewImageMapper;
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    private Camp mockCamp;
+    private Reservation mockReservation;
+    private Review mockReview;
+
+    @BeforeEach
+    void setUp() {
+        mockCamp = Camp.builder()
+                .id(1L)
+                .campName("Mock Camp")
+                .build();
+
+        mockReservation = Reservation.builder()
+                .id(1L)
+                .campSite(CampSite.builder()
+                        .siteType(CAR_SITE)
+                        .price(CAR_SITE.getPrice())
+                        .maximumPeople(CAR_SITE.getMaximum_people())
+                        .build())
+                .user(User.builder()
+                        .id(123L)
+                        .name("Mock User")
+                        .email("mockuser@example.com")
+                        .build())
+                .checkIn(LocalDateTime.of(2024, 12, 1, 14, 0))
+                .checkOut(LocalDateTime.of(2024, 12, 3, 11, 0))
+                .guestCnt(2)
+                .status(ReservationStatus.COMPLETED)
+                .totalPrice(160000)
+                .build();
+
+        mockReview = Review.builder()
+                .content("Great camping experience!")
+                .isRecommend(true)
+                .camp(mockCamp)
+                .reservation(mockReservation)
+                .build();
+    }
+
+    @Test
+    @DisplayName("리뷰 생성 성공")
+    void createReview_Success() throws IOException {
+        // Given
+        ReviewCreateRequestDto requestDto = createMockReviewRequest();
+        Review savedReview = createSavedReview(mockReview);
+        List<String> uploadedUrls = List.of("url1", "url2");
+        List<ReviewImage> reviewImages = createMockReviewImages(savedReview, uploadedUrls);
+
+        mockCampAndReservationFindById();
+
+        when(reviewMapper.toEntity(requestDto, mockCamp, mockReservation)).thenReturn(mockReview);
+        when(reviewRepository.save(mockReview)).thenReturn(savedReview);
+        when(s3BucketService.upload(requestDto.getS3Images(), "reviews/1")).thenReturn(uploadedUrls);
+        when(reviewImageMapper.toEntityList(uploadedUrls, savedReview)).thenReturn(reviewImages);
+        when(reviewImageRepository.saveAll(reviewImages)).thenReturn(reviewImages);
+        when(reviewMapper.toResponseDto(savedReview)).thenReturn(
+                ReviewResponseDto.builder()
+                        .reviewId(savedReview.getId())
+                        .content(savedReview.getContent())
+                        .isRecommend(savedReview.isRecommend())
+                        .build()
+        );
+
+        // When
+        ReviewResponseDto responseDto = reviewService.createReview(1L, 1L, requestDto);
+
+        // Then
+        assertNotNull(responseDto);
+        assertEquals(savedReview.getId(), responseDto.getReviewId());
+        assertEquals(requestDto.getContent(), responseDto.getContent());
+        assertEquals(requestDto.isRecommend(), responseDto.isRecommend());
+
+        verify(reviewRepository, times(1)).save(mockReview);
+        verify(reviewImageRepository, times(1)).saveAll(reviewImages);
+        verify(s3BucketService, times(1)).upload(requestDto.getS3Images(), "reviews/1");
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 성공")
+    void updateReview_Success() throws IOException {
+        // Given
+        ReviewUpdateRequestDto requestDto = createMockUpdateRequest();
+        Review existingReview = createSavedReview(mockReview);
+        List<ReviewImage> oldReviewImages = List.of(
+                ReviewImage.builder().imageUrl("old_url1").build(),
+                ReviewImage.builder().imageUrl("old_url2").build()
+        );
+
+        when(reviewRepository.findById(1L)).thenReturn(Optional.of(existingReview));
+        when(reviewImageRepository.findByReview(existingReview)).thenReturn(oldReviewImages);
+
+        // When
+        reviewService.updateReview(1L, 1L, requestDto);
+
+        // Then
+        verify(reviewImageRepository).deleteAll(oldReviewImages);
+        verify(s3BucketService).upload(requestDto.getS3Images(), "reviews/1");
+    }
+
+    // Helper Methods
+    private void mockCampAndReservationFindById() {
+        when(campRepository.findById(1L)).thenReturn(Optional.of(mockCamp));
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(mockReservation));
+    }
+
+    private ReviewCreateRequestDto createMockReviewRequest() {
+        return ReviewCreateRequestDto.builder()
+                .content("Great camping experience!")
+                .isRecommend(true)
+                .s3Images(List.of(
+                        new MockMultipartFile("image1", "image1.jpg", "image/jpeg", "dummy image content".getBytes()),
+                        new MockMultipartFile("image2", "image2.jpg", "image/jpeg", "dummy image content".getBytes())
+                ))
+                .build();
+    }
+
+    private ReviewUpdateRequestDto createMockUpdateRequest() {
+        return ReviewUpdateRequestDto.builder()
+                .content("Updated Content")
+                .isRecommend(false)
+                .s3Images(List.of(
+                        new MockMultipartFile("image1", "updated_image1.jpg", "image/jpeg", "updated dummy image content".getBytes()),
+                        new MockMultipartFile("image2", "updated_image2.jpg", "image/jpeg", "updated dummy image content".getBytes())
+                ))
+                .build();
+    }
+
+    private Review createSavedReview(Review baseReview) {
+        return Review.builder()
+                .id(1L)
+                .content(baseReview.getContent())
+                .isRecommend(baseReview.isRecommend())
+                .camp(baseReview.getCamp())
+                .reservation(baseReview.getReservation())
+                .build();
+    }
+
+    private List<ReviewImage> createMockReviewImages(Review review, List<String> urls) {
+        return List.of(
+                ReviewImage.builder().imageUrl(urls.get(0)).review(review).build(),
+                ReviewImage.builder().imageUrl(urls.get(1)).review(review).build()
+        );
+    }
+
+    @Test
+    @DisplayName("캠핑장의 리뷰 조회 성공")
+    void getReviewsByCampId_Success() {
+        // Given
+        Long campId = 1L; // 캠프 ID
+        Camp mockCamp = Camp.builder().id(campId).campName("Mock Camp").build();
+
+        List<Review> mockReviews = List.of(
+                Review.builder().id(1L).content("Great camping experience!").camp(mockCamp).isRecommend(true).build(),
+                Review.builder().id(2L).content("Could be better.").camp(mockCamp).isRecommend(false).build()
+        );
+
+        List<ReviewResponseDto> expectedResponseDtos = List.of(
+                ReviewResponseDto.builder().reviewId(1L).content("Great camping experience!").isRecommend(true).build(),
+                ReviewResponseDto.builder().reviewId(2L).content("Could be better.").isRecommend(false).build()
+        );
+
+        // Mock 설정
+        when(campRepository.findById(campId)).thenReturn(Optional.of(mockCamp));
+        when(reviewRepository.findByCampId(campId)).thenReturn(mockReviews);
+        when(reviewMapper.toResponseDtoList(mockReviews)).thenReturn(expectedResponseDtos);
+
+        // When
+        List<ReviewResponseDto> responseDtos = reviewService.getReviewsByCampId(campId);
+
+        // Then
+        assertNotNull(responseDtos);
+        assertEquals(2, responseDtos.size());
+        assertEquals("Great camping experience!", responseDtos.get(0).getContent());
+        assertEquals("Could be better.", responseDtos.get(1).getContent());
+
+        // Mock 호출 검증
+        verify(campRepository, times(1)).findById(campId);
+        verify(reviewRepository, times(1)).findByCampId(campId);
+        verify(reviewMapper, times(1)).toResponseDtoList(mockReviews);
+    }
+
+
+//    @Test
+//    @DisplayName("캠핑지의 리뷰 조회 성공")
+//    void getReviewsByCampSiteId_Success() {
+//        // Given
+//        Long campSiteId = 1L;
+//        CampSite mockCampSite = CampSite.builder().id(campSiteId).siteType(CAR_SITE).build();
+//        List<Review> mockReviews = List.of(
+//                Review.builder().id(1L).content("Amazing site!").campSite(mockCampSite).isRecommend(true).build(),
+//                Review.builder().id(2L).content("Not bad.").campSite(mockCampSite).isRecommend(false).build()
+//        );
+//        List<ReviewResponseDto> expectedResponseDtos = List.of(
+//                ReviewResponseDto.builder().reviewId(1L).content("Amazing site!").isRecommend(true).build(),
+//                ReviewResponseDto.builder().reviewId(2L).content("Not bad.").isRecommend(false).build()
+//        );
+//
+//        when(reviewRepository.findByCampSiteId(campSiteId)).thenReturn(mockReviews);
+//        when(reviewMapper.toResponseDtoList(mockReviews)).thenReturn(expectedResponseDtos);
+//
+//        // When
+//        List<ReviewResponseDto> responseDtos = reviewService.getReviewsByCampSiteId(campSiteId);
+//
+//        // Then
+//        assertNotNull(responseDtos);
+//        assertEquals(2, responseDtos.size());
+//        assertEquals("Amazing site!", responseDtos.get(0).getContent());
+//        assertEquals("Not bad.", responseDtos.get(1).getContent());
+//
+//        verify(reviewRepository, times(1)).findByCampSiteId(campSiteId);
+//        verify(reviewMapper, times(1)).toResponseDtoList(mockReviews);
+//    }
+
+
+    @Test
+    @DisplayName("리뷰 삭제 성공")
+    void deleteReview_Success() {
+        // Given
+        Long reviewId = 1L;
+        Review existingReview = createSavedReview(mockReview);
+        List<ReviewImage> reviewImages = List.of(
+                ReviewImage.builder().imageUrl("url1").build(),
+                ReviewImage.builder().imageUrl("url2").build()
+        );
+
+        when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(existingReview));
+        when(reviewImageRepository.findByReview(existingReview)).thenReturn(reviewImages);
+
+        // When
+        reviewService.deleteReview(reviewId);
+
+        // Then
+        verify(reviewImageRepository, times(1)).findByReview(existingReview);
+        verify(reviewImageRepository, times(1)).deleteAll(reviewImages);
+        verify(s3BucketService, times(1)).remove(reviewImages.get(0).getImageUrl());
+        verify(s3BucketService, times(1)).remove(reviewImages.get(1).getImageUrl());
+        verify(reviewRepository, times(1)).delete(existingReview);
+    }
+
+    @Test
+    @DisplayName("리뷰 추천 상태 변경 - 권한 있는 유저일 때 성공적으로 추천 상태 변경")
+    void toggleRecommend_ShouldToggleRecommendStatus_WhenUserIsAuthorized() {
+        // Given
+        Long reviewId = 1L;
+        Long userId = 2L;
+
+        // Mocking Review 객체 생성
+        Review review = Review.builder()
+                .id(reviewId)
+                .isRecommend(false)
+                .reservation(Reservation.builder()
+                        .user(User.builder().id(userId).build())
+                        .build())
+                .build();
+
+        // 상태가 변경된 Review 객체
+        Review updatedReview = Review.builder()
+                .id(reviewId)
+                .isRecommend(true)
+                .reservation(review.getReservation())
+                .build();
+
+        // Mocking
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+        given(reviewMapper.toUpdatedReview(review)).willReturn(updatedReview);
+        given(reviewRepository.save(updatedReview)).willReturn(updatedReview);
+
+        // When
+        boolean isRecommended = reviewService.toggleRecommend(reviewId, userId);
+
+        // Then
+        assertThat(isRecommended).isTrue();
+        verify(reviewRepository).findById(reviewId);
+        verify(reviewMapper).toUpdatedReview(review);
+        verify(reviewRepository).save(updatedReview);
+    }
+
+    @Test
+    @DisplayName("리뷰 추천 상태 변경 - 리뷰를 찾을 수 없을 때 예외 발생")
+    void toggleRecommend_ShouldThrowException_WhenReviewNotFound() {
+        // Given
+        Long reviewId = 1L;
+        Long userId = 2L;
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> reviewService.toggleRecommend(reviewId, userId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("Review not found with ID: " + reviewId);
+
+        verify(reviewRepository).findById(reviewId);
+        verifyNoMoreInteractions(reviewMapper, reviewRepository);
+    }
+
+    @Test
+    @DisplayName("리뷰 추천 상태 변경 - 권한 없는 유저일 때 예외 발생")
+    void toggleRecommend_ShouldThrowException_WhenUserIsNotAuthorized() {
+        // Given
+        Long reviewId = 1L;
+        Long userId = 2L;
+
+        // Mocking Review 객체 생성 (userId 불일치)
+        Review review = Review.builder()
+                .id(reviewId)
+                .isRecommend(false)
+                .reservation(Reservation.builder()
+                        .user(User.builder().id(3L).build()) // 다른 User ID
+                        .build())
+                .build();
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+        // When & Then
+        assertThatThrownBy(() -> reviewService.toggleRecommend(reviewId, userId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("User is not authorized to toggle recommend for this review.");
+
+        verify(reviewRepository).findById(reviewId);
+        verifyNoMoreInteractions(reviewMapper, reviewRepository);
+    }
+
+}


### PR DESCRIPTION
## 📌 목적
- 리뷰 작성, 수정, 추천 토글 기능을 구현하여 리뷰를 사용하기 위함

## 🛠️ 작업 상세 내용
- [x] 리뷰 작성 기능 구현 (`ReviewCreateRequestDto` 활용)
- [x] 리뷰 수정 기능 구현 (`ReviewUpdateRequestDto` 활용)
- [x] 리뷰 추천 상태 토글 기능 (`toggleRecommend`) 추가
- [x] `ReviewMapper`를 활용한 리뷰 엔티티 변환 로직 작성
- [x] `ReviewServiceTest`에 테스트 케이스 추가 (추천 토글, 예외 처리 등)

## 🔍 변경 사항
- `ReviewController`에서 리뷰 생성, 수정, 추천 토글 API 구현
- `ReviewService`에 비즈니스 로직 추가 (추천 상태 변경 및 유저 권한 확인)
- `ReviewMapper`를 활용한 엔티티 변경 로직 추가
- 리뷰 이미지 관리와 관련된 `ReviewImageMapper`, `ReviewImageRepository` 추가 & AWS S3 사용
- 리뷰 관련 테스트 코드 작성 및 검증
- 캠핑장, 캠핑지 엔티티 소규모 수정

## ✅ 테스트 방법
1. [x] `ReviewServiceTest`에서 유효한 유저의 추천 상태 변경 성공 테스트
2. [x] 잘못된 유저 ID나 리뷰 ID로 예외 발생 여부 테스트

## ⚠️ 주의 사항
- [ ] 예약 상태를 기준으로 리뷰를 작성하는 기능은 주석 처리(추후 논의 예정)