### PR TITLE
[Fix] CampAddr Point 타입 변경에 대한 CampServiceTest 수정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
 
     //공간데이터 저장 hibernate-spatial
     implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.1.0.Final'
+    implementation 'org.locationtech.jts:jts-core:1.20.0'
 
     //dev-tools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -73,6 +74,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 test {

--- a/src/main/java/site/campingon/campingon/camp/entity/Camp.java
+++ b/src/main/java/site/campingon/campingon/camp/entity/Camp.java
@@ -41,23 +41,23 @@ public class Camp{
   @Column(name = "thumb_image", length = 255)
   private String thumbImage;  // 썸네일 이미지
 
-  @OneToMany(mappedBy = "camp", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "camp", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CampKeyword> keywords;
 
-  @OneToMany(mappedBy = "camp", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "camp", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CampImage> images;
 
-  @OneToMany(mappedBy = "camp",cascade = CascadeType.ALL,fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "camp",cascade = CascadeType.ALL, orphanRemoval = true)
   @Column(length = 100, nullable = false)
   private List<CampInduty> induty;  // 업종
 
-  @OneToOne(mappedBy = "camp", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @OneToOne(mappedBy = "camp", cascade = CascadeType.ALL, orphanRemoval = true)
   private CampAddr campAddr;
 
-  @OneToOne(mappedBy = "camp", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @OneToOne(mappedBy = "camp", cascade = CascadeType.ALL, orphanRemoval = true)
   private CampInfo campInfo;
 
-  @OneToMany(mappedBy = "camp", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "camp", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Bookmark> bookmarks;
 
   @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME")

--- a/src/main/java/site/campingon/campingon/camp/entity/CampAddr.java
+++ b/src/main/java/site/campingon/campingon/camp/entity/CampAddr.java
@@ -1,6 +1,6 @@
 package site.campingon.campingon.camp.entity;
 
-import com.vividsolutions.jts.geom.Point;   //jts 사용..!!
+import org.locationtech.jts.geom.Point;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,7 +39,7 @@ public class CampAddr {
     @Column(nullable = false)
     private Double latitude;  // maxY - 위도*/
 
-    @Column(columnDefinition = "GEOMETRY", nullable = false)
+    @Column(name = "location", updatable = false, nullable = false)
     private Point location;
 
     @Column(name = "street_addr", length = 50)

--- a/src/main/java/site/campingon/campingon/common/exception/ErrorCode.java
+++ b/src/main/java/site/campingon/campingon/common/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     USER_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "ACCOUNT-003", "해당 아이디의 회원을 찾을 수 없습니다."),
 
     CAMP_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "CAMP-001", "캠핑장의 ID를 찾을 수 없습니다."),
+    CAMP_NOT_FOUND(HttpStatus.NOT_FOUND, "CAMP-002", "캠핑장을 찾을 수 없습니다."),
 
     CAMP_INDUTY_NOT_FOUND(HttpStatus.NOT_FOUND, "INDUTY-001", "존재하지 않는 업종입니다."),
 

--- a/src/main/java/site/campingon/campingon/common/public_data/controller/GoCampingController.java
+++ b/src/main/java/site/campingon/campingon/common/public_data/controller/GoCampingController.java
@@ -1,6 +1,6 @@
 package site.campingon.campingon.common.public_data.controller;
 
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.ParseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/site/campingon/campingon/common/public_data/schedule/GoCampingScheduler.java
+++ b/src/main/java/site/campingon/campingon/common/public_data/schedule/GoCampingScheduler.java
@@ -1,6 +1,6 @@
 package site.campingon.campingon.common.public_data.schedule;
 
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.ParseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;

--- a/src/main/java/site/campingon/campingon/common/public_data/service/GoCampingService.java
+++ b/src/main/java/site/campingon/campingon/common/public_data/service/GoCampingService.java
@@ -1,9 +1,9 @@
 package site.campingon.campingon.common.public_data.service;
 
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/test/java/site/campingon/campingon/camp/service/CampServiceTest.java
+++ b/src/test/java/site/campingon/campingon/camp/service/CampServiceTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.io.WKTReader;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -11,7 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Point;
 import site.campingon.campingon.bookmark.repository.BookmarkRepository;
 import site.campingon.campingon.camp.dto.CampDetailResponseDto;
 import site.campingon.campingon.camp.dto.CampListResponseDto;
@@ -68,12 +70,23 @@ class CampServiceTest {
 
   @BeforeEach
   void setUp() {
+    GeometryFactory geometryFactory = new GeometryFactory();
+
+    // WKT(Well-Known Text) 형식으로 포인트 생성
+    Point point = null;
+    try {
+      String pointWKT = "POINT(127.0 37.0)";
+      point = (Point) new WKTReader(geometryFactory).read(pointWKT);
+    } catch (org.locationtech.jts.io.ParseException e) {
+      throw new RuntimeException("Point 생성 중 오류 발생", e);
+    }
+
     mockCampAddr = CampAddr.builder()
         .id(1L)
         .city("TestCity")
         .state("TestState")
         .zipcode("12345")
-        .location(new Point(127.0, 37.0))
+        .location(point)  // 생성된 JTS Point 객체 설정
         .streetAddr("Test Street")
         .build();
 

--- a/src/test/java/site/campingon/campingon/camp/service/CampServiceTest.java
+++ b/src/test/java/site/campingon/campingon/camp/service/CampServiceTest.java
@@ -247,6 +247,16 @@ class CampServiceTest {
     assertEquals(mockCampDetailDto.getName(), result.getName());
     assertEquals("일반야영장, 자동차야영장", result.getIndutys());
 
+    // CampAddr 관련 검증
+    assertNotNull(result.getCampAddr());
+    assertEquals(mockCampAddr.getCity(), result.getCampAddr().getCity());
+    assertEquals(mockCampAddr.getState(), result.getCampAddr().getState());
+
+    // CampInfo 관련 검증
+    assertNotNull(result.getCampInfo());
+    assertEquals(mockCampInfo.getRecommendCnt(), result.getCampInfo().getRecommendCnt());
+    assertEquals(mockCampInfo.getBookmarkCnt(), result.getCampInfo().getBookmarkCnt());
+
     verify(campRepository).findById(campId);
     verify(campMapper).toCampDetailDto(mockCamp);
   }


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] Camp 엔티티의 연관 객체별 지연 로딩 제거, orphanRemoval = true추가
- [x] CampServiceTest의 MockCampAddr 수정된 Point 타입 형식으로 수정
- [x] CampServiceTest의 캠핑장 상세 조회에 응답에서 nested된 CampAddr, CampInfo 객체 관련 검증
- [x] BuildGradle에 의존성 추가 

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- Camp 엔티티 연관 객체별 지연로딩 제거 후 Camp삭제시 연관 자식 객체 삭제 추가 
- CampServiceTest 오류 부분 수정 및 검증
- CampAddr 객체의 import org.locationtech.jts.geom.Point선언으로 수정 
- locationtech.jts관련 의존성 추가 

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [x] 테스트 케이스 작성
2. [ ] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #