### PR TITLE
Feat/#139 reservation 예약 가능한 캠프사이트 조회 api 통합

### DIFF
--- a/src/main/java/site/campingon/campingon/camp/controller/CampSiteController.java
+++ b/src/main/java/site/campingon/campingon/camp/controller/CampSiteController.java
@@ -17,6 +17,8 @@ import java.util.List;
 public class CampSiteController {
   private final CampSiteService campSiteService;
 
+  // REFACTOR: ReservationController.getAvailableCampSites()으로 통합
+  // 캠핑지 목록 조회
   // 캠핑장의 예약가능한 캠핑지 목록 조회
   @GetMapping("/{campId}/available-sites")
   public ResponseEntity<List<CampSiteListResponseDto>> getAvailableCampSites(

--- a/src/main/java/site/campingon/campingon/camp/service/CampSiteService.java
+++ b/src/main/java/site/campingon/campingon/camp/service/CampSiteService.java
@@ -30,8 +30,7 @@ public class CampSiteService {
     @Transactional
     public CampSiteResponseDto createCampSite(Long campId, CampSiteCreateRequestDto createRequestDto) {
         Camp camp = campRepository.findById(campId)
-            .orElseThrow(() -> new GlobalException(ErrorCode.CAMP_NOT_FOUND_BY_ID));
-
+                .orElseThrow(() -> new GlobalException(ErrorCode.CAMP_NOT_FOUND_BY_ID));
         CampSite campSite = campSiteMapper.toCampSite(createRequestDto, camp);
         return campSiteMapper.toCampSiteResponseDto(campSiteRepository.save(campSite));
     }
@@ -64,6 +63,7 @@ public class CampSiteService {
                 .toList();
     }
 
+    // REFACTOR: ReservationService.getAvailableCampSites()으로 통합
     // 캠핑장의 예약 가능한 SiteType별 캠핑지 조회
     public List<CampSiteListResponseDto> getAvailableCampSites(Long campId, List<Long> reservedSiteIds) {
         // 해당 캠핑장의 모든 캠프사이트 조회

--- a/src/main/java/site/campingon/campingon/common/exception/ErrorCode.java
+++ b/src/main/java/site/campingon/campingon/common/exception/ErrorCode.java
@@ -45,11 +45,8 @@ public enum ErrorCode {
     CAMP_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "CAMP-001", "캠핑장의 ID를 찾을 수 없습니다."),
     CAMP_NOT_FOUND(HttpStatus.NOT_FOUND, "CAMP-002", "캠핑장을 찾을 수 없습니다."),
 
-    CAMPSITE_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "CAMPSITE-001", "캠핑지의 ID를 찾을 수 없습니다."),
-
     REVIEW_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "REVIEW-001", "해당 리뷰를 찾을 수 없습니다."),
     REVIEW_NOT_IN_CAMP(HttpStatus.NOT_FOUND, "REVIEW-002", "리뷰가 해당 캠프에 속하지 않습니다."),
-
 
     CAMP_INDUTY_NOT_FOUND(HttpStatus.NOT_FOUND, "INDUTY-001", "존재하지 않는 업종입니다."),
 

--- a/src/main/java/site/campingon/campingon/reservation/controller/ReservationController.java
+++ b/src/main/java/site/campingon/campingon/reservation/controller/ReservationController.java
@@ -33,7 +33,7 @@ public class ReservationController {
         return ResponseEntity.ok(reservationService.getReservations(userDetails.getId(), pageable));
     }
 
-    // 새로운 예약 후 확인을 위한 조회
+    // 단일 예약 정보 조회
     @GetMapping("/{reservationId}")
     public ResponseEntity<ReservationResponseDto> getReservation(@PathVariable("reservationId") Long reservationId) {
 
@@ -42,9 +42,9 @@ public class ReservationController {
 
     // 새로운 예약 생성
     @PostMapping
-    public ResponseEntity<Void> createReservation(@RequestBody ReservationCreateRequestDto requestDto) {
+    public ResponseEntity<Void> createReservation(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody ReservationCreateRequestDto requestDto) {
 
-        reservationService.createReservation(requestDto);
+        reservationService.createReservation(userDetails.getId(), requestDto);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/site/campingon/campingon/reservation/controller/ReservationController.java
+++ b/src/main/java/site/campingon/campingon/reservation/controller/ReservationController.java
@@ -17,17 +17,19 @@ import site.campingon.campingon.reservation.service.ReservationService;
 @RequestMapping("/api/reservations")
 public class ReservationController {
 
+    @Value("${app.pagination.reservation.page}")
+    private int page;
+
     @Value("${app.pagination.reservation.size}")
-    private int pageSize;
+    private int size;
 
 
     private final ReservationService reservationService;
 
     // 유저의 예약 목록 조회
     @GetMapping
-    public ResponseEntity<Page<ReservationResponseDto>> getReservations(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                        @RequestParam("page") int page) {
-        Pageable pageable = PageRequest.of(page, pageSize);
+    public ResponseEntity<Page<ReservationResponseDto>> getReservations(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(reservationService.getReservations(userDetails.getId(), pageable));
     }
 

--- a/src/main/java/site/campingon/campingon/reservation/controller/ReservationController.java
+++ b/src/main/java/site/campingon/campingon/reservation/controller/ReservationController.java
@@ -26,14 +26,14 @@ public class ReservationController {
     // 유저의 예약 목록 조회
     @GetMapping
     public ResponseEntity<Page<ReservationResponseDto>> getReservations(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                        @RequestParam int page) {
+                                                                        @RequestParam("page") int page) {
         Pageable pageable = PageRequest.of(page, pageSize);
         return ResponseEntity.ok(reservationService.getReservations(userDetails.getId(), pageable));
     }
 
     // 새로운 예약 후 확인을 위한 조회
     @GetMapping("/{reservationId}")
-    public ResponseEntity<ReservationResponseDto> getReservation(@PathVariable Long reservationId) {
+    public ResponseEntity<ReservationResponseDto> getReservation(@PathVariable("reservationId") Long reservationId) {
 
         return ResponseEntity.ok(reservationService.getReservation(reservationId));
     }
@@ -49,7 +49,7 @@ public class ReservationController {
 
     // 예약 취소
     @PatchMapping("/{reservationId}")
-    public ResponseEntity<Void> cancelReservation(@PathVariable Long reservationId, @RequestBody ReservationCancelRequestDto requestDto) {
+    public ResponseEntity<Void> cancelReservation(@PathVariable("reservationId") Long reservationId, @RequestBody ReservationCancelRequestDto requestDto) {
         
         reservationService.cancelReservation(reservationId, requestDto);
 

--- a/src/main/java/site/campingon/campingon/reservation/controller/ReservationController.java
+++ b/src/main/java/site/campingon/campingon/reservation/controller/ReservationController.java
@@ -8,9 +8,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import site.campingon.campingon.camp.dto.CampSiteResponseDto;
 import site.campingon.campingon.common.jwt.CustomUserDetails;
 import site.campingon.campingon.reservation.dto.*;
 import site.campingon.campingon.reservation.service.ReservationService;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -58,10 +61,17 @@ public class ReservationController {
         return ResponseEntity.ok().build();
     }
 
-    // 해당 날짜에 예약된 캠프사이트 조회
-    @GetMapping("/available")
+    // 해당 날짜에 이미 예약된 캠프사이트 ID 목록 조회
+    @GetMapping("/reserved")
     public ResponseEntity<ReservedCampSiteIdListResponseDto> getReservedCampSiteIds(@RequestBody ReservationCheckDateRequestDto requestDto) {
 
         return ResponseEntity.ok(reservationService.getReservedCampSiteIds(requestDto));
+    }
+
+    // 해당 날짜에 예약 가능한 캠프사이트 조회
+    @GetMapping("/available")
+    public ResponseEntity<List<CampSiteResponseDto>> getAvailableCampSites(@RequestBody ReservationCheckDateRequestDto requestDto) {
+
+        return ResponseEntity.ok(reservationService.getAvailableCampSites(requestDto));
     }
 }

--- a/src/main/java/site/campingon/campingon/reservation/dto/ReservationCheckDateRequestDto.java
+++ b/src/main/java/site/campingon/campingon/reservation/dto/ReservationCheckDateRequestDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @ToString
@@ -15,8 +15,8 @@ public class ReservationCheckDateRequestDto {
 
     private Long campId;
 
-    private LocalDateTime checkIn;
+    private LocalDate checkIn;
 
-    private LocalDateTime checkOut;
+    private LocalDate checkOut;
 
 }

--- a/src/main/java/site/campingon/campingon/reservation/dto/ReservationCreateRequestDto.java
+++ b/src/main/java/site/campingon/campingon/reservation/dto/ReservationCreateRequestDto.java
@@ -11,8 +11,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ReservationCreateRequestDto {
 
-    private Long userId;
-
     private Long campId;
 
     private Long campSiteId;

--- a/src/main/java/site/campingon/campingon/reservation/dto/ReservationCreateRequestDto.java
+++ b/src/main/java/site/campingon/campingon/reservation/dto/ReservationCreateRequestDto.java
@@ -1,9 +1,9 @@
 package site.campingon.campingon.reservation.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
-import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @ToString
@@ -15,11 +15,11 @@ public class ReservationCreateRequestDto {
 
     private Long campSiteId;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
-    private LocalDateTime checkIn;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate checkIn;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
-    private LocalDateTime checkOut;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate checkOut;
 
     private int guestCnt;
 

--- a/src/main/java/site/campingon/campingon/reservation/entity/CheckTime.java
+++ b/src/main/java/site/campingon/campingon/reservation/entity/CheckTime.java
@@ -1,0 +1,16 @@
+package site.campingon.campingon.reservation.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+@AllArgsConstructor
+public enum CheckTime {
+    CHECKIN(LocalTime.of(15, 0)),
+    CHECKOUT(LocalTime.of(11, 0));
+
+    private final LocalTime time;
+
+}

--- a/src/main/java/site/campingon/campingon/reservation/entity/Reservation.java
+++ b/src/main/java/site/campingon/campingon/reservation/entity/Reservation.java
@@ -2,13 +2,13 @@ package site.campingon.campingon.reservation.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.format.annotation.DateTimeFormat;
 import site.campingon.campingon.camp.entity.Camp;
 import site.campingon.campingon.camp.entity.CampSite;
 import site.campingon.campingon.common.entity.BaseEntity;
 import site.campingon.campingon.user.entity.User;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -35,11 +35,19 @@ public class Reservation extends BaseEntity {
     @JoinColumn(nullable = false)
     private CampSite campSite;
 
-    @Column(nullable = false, columnDefinition = "DATETIME(0)")
-    private LocalDateTime checkIn;
+    @Column(nullable = false, columnDefinition = "DATE")
+    private LocalDate checkInDate;
 
-    @Column(nullable = false, columnDefinition = "DATETIME(0)")
-    private LocalDateTime checkOut;
+    @Column(nullable = false, columnDefinition = "DATE")
+    private LocalDate checkOutDate;
+
+    @Builder.Default
+    @Column(nullable = false, columnDefinition = "TIME(0)")
+    private CheckTime checkInTime = CheckTime.CHECKIN;
+
+    @Builder.Default
+    @Column(nullable = false, columnDefinition = "TIME(0)")
+    private CheckTime checkOutTime = CheckTime.CHECKOUT;
 
     @Column(nullable = false)
     private int guestCnt;

--- a/src/main/java/site/campingon/campingon/reservation/repository/ReservationRepository.java
+++ b/src/main/java/site/campingon/campingon/reservation/repository/ReservationRepository.java
@@ -7,9 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import site.campingon.campingon.camp.entity.CampSite;
 import site.campingon.campingon.reservation.entity.Reservation;
 import site.campingon.campingon.reservation.entity.ReservationStatus;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -20,17 +22,27 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     // 유저의 모든 예약 조회
     Page<Reservation> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
-    // 특정 캠프장의 특정 날짜에 예약된 캠프사이트 ID 목록 조회 (일자까지만 파싱해서 조회)
+    // 특정 캠핑장의 특정 날짜에 예약된 캠프사이트 ID 목록 조회 (일자만 조회)
     @Query("SELECT r.campSite.id FROM Reservation r " +
             "WHERE r.camp.id = :campId " +
             "AND r.status = 'RESERVED' " +
-            "AND CAST(r.checkIn AS date) < CAST(:checkOut AS date) " +
-            "AND CAST(r.checkOut AS date) > CAST(:checkIn AS date)")
-    List<Long> findReservedCampSiteIds(
-            @Param("campId") Long campId,
-            @Param("checkIn") LocalDateTime checkIn,
-            @Param("checkOut") LocalDateTime checkOut
-    );
+            "AND r.checkInDate < :checkOut " +
+            "AND r.checkOutDate > :checkIn")
+    List<Long> findReservedCampSiteIds(@Param("campId") Long campId,
+                                       @Param("checkIn") LocalDate checkIn,
+                                       @Param("checkOut") LocalDate checkOut);
+
+    // 특정 캠핑장의 특정 날짜에 예약 가능한 캠프사이트를 타입별로 1개 반환되게끔 조회
+    @Query("SELECT cs FROM CampSite cs " +
+            "LEFT JOIN Reservation r ON cs.id = r.campSite.id " +
+            "WHERE cs.isAvailable = true " +
+            "AND cs.camp.id = :campId " +
+            "AND (r.id IS NULL OR r.status = 'CANCELED') " + // 예약테이블에 없거나 취소상태여야 함
+            "AND (r.checkInDate < :checkOut AND r.checkOutDate > :checkIn) " +
+            "ORDER BY cs.id ASC")
+    List<CampSite> findAvailableCampSites(@Param("campId") Long campId,
+                                                           @Param("checkIn") LocalDate checkIn,
+                                                           @Param("checkOut") LocalDate checkOut);
 
     // 특정 예약의 상세 정보 조회 (연관된 캠프, 주소 정보 포함)
     @EntityGraph(attributePaths = {"camp", "campSite"})

--- a/src/main/java/site/campingon/campingon/reservation/service/ReservationService.java
+++ b/src/main/java/site/campingon/campingon/reservation/service/ReservationService.java
@@ -2,7 +2,10 @@ package site.campingon.campingon.reservation.service;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import site.campingon.campingon.camp.dto.CampSiteResponseDto;
 import site.campingon.campingon.reservation.dto.*;
+
+import java.util.List;
 
 public interface ReservationService {
 
@@ -20,5 +23,8 @@ public interface ReservationService {
 
     // 예약가능한 캠프사이트 조회를 위해 특정 날짜에 예약이 됐는지 조회
     ReservedCampSiteIdListResponseDto getReservedCampSiteIds(ReservationCheckDateRequestDto requestDto);
+
+    // 예약가능한 캠프사이트를 타입별로 하나씩 조회
+    List<CampSiteResponseDto> getAvailableCampSites(ReservationCheckDateRequestDto requestDto);
 
 }

--- a/src/main/java/site/campingon/campingon/reservation/service/ReservationService.java
+++ b/src/main/java/site/campingon/campingon/reservation/service/ReservationService.java
@@ -13,7 +13,7 @@ public interface ReservationService {
     ReservationResponseDto getReservation(Long reservationId);
 
     // 캠프사이트 선택 후 예약 요청
-    void createReservation(ReservationCreateRequestDto requestDto);
+    void createReservation(Long userId, ReservationCreateRequestDto requestDto);
 
     // 예약완료 이후 예약취소 요청
     void cancelReservation(Long reservationId, ReservationCancelRequestDto requestDto);

--- a/src/main/java/site/campingon/campingon/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/site/campingon/campingon/reservation/service/ReservationServiceImpl.java
@@ -5,7 +5,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.campingon.campingon.camp.dto.CampSiteResponseDto;
 import site.campingon.campingon.camp.entity.CampSite;
+import site.campingon.campingon.camp.mapper.CampSiteMapper;
 import site.campingon.campingon.reservation.dto.*;
 import site.campingon.campingon.reservation.repository.ReservationRepository;
 import site.campingon.campingon.reservation.mapper.ReservationMapper;
@@ -14,11 +16,13 @@ import site.campingon.campingon.reservation.utils.ReservationValidate;
 import site.campingon.campingon.user.entity.User;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationServiceImpl implements ReservationService {
 
+    private final CampSiteMapper campSiteMapper;
     private final ReservationMapper reservationMapper;
     private final ReservationValidate reservationValidate;
     private final ReservationRepository reservationRepository;
@@ -42,24 +46,23 @@ public class ReservationServiceImpl implements ReservationService {
     }
 
 
-
     // 캠프사이트 선택 후 예약 요청
     @Transactional
     public void createReservation(Long userId, ReservationCreateRequestDto requestDto) {
 
         User user = reservationValidate.validateUserById(userId);
-        
+
         CampSite campSite = reservationValidate.validateCampSiteById(requestDto.getCampId());
 
         Reservation reservation = Reservation.builder()
-            .user(user)
-            .camp(campSite.getCamp())
-            .campSite(campSite)
-            .checkIn(requestDto.getCheckIn())
-            .checkOut(requestDto.getCheckOut())
-            .guestCnt(requestDto.getGuestCnt())
-            .totalPrice(requestDto.getTotalPrice())
-            .build();
+                .user(user)
+                .camp(campSite.getCamp())
+                .campSite(campSite)
+                .checkInDate(requestDto.getCheckIn())
+                .checkOutDate(requestDto.getCheckOut())
+                .guestCnt(requestDto.getGuestCnt())
+                .totalPrice(requestDto.getTotalPrice())
+                .build();
 
         reservationRepository.save(reservation);
     }
@@ -72,13 +75,12 @@ public class ReservationServiceImpl implements ReservationService {
         reservationValidate.validateStatus(requestDto.getStatus());
 
         Reservation canceledReservation = reservation.toBuilder()
-            .status(requestDto.getStatus())
-            .cancelReason(requestDto.getCancelReason())
-            .build();
+                .status(requestDto.getStatus())
+                .cancelReason(requestDto.getCancelReason())
+                .build();
 
         reservationRepository.save(canceledReservation);
     }
-
 
 
     // 예약가능한 캠프사이트 조회를 위해 특정 날짜에 예약이 됐는지 조회
@@ -86,11 +88,28 @@ public class ReservationServiceImpl implements ReservationService {
     public ReservedCampSiteIdListResponseDto getReservedCampSiteIds(ReservationCheckDateRequestDto requestDto) {
 
         List<Long> reservedIds = reservationRepository.findReservedCampSiteIds(
-            requestDto.getCampId(),
-            requestDto.getCheckIn(),
-            requestDto.getCheckOut()
-        );
+                requestDto.getCampId(),
+                requestDto.getCheckIn(),
+                requestDto.getCheckOut());
 
         return new ReservedCampSiteIdListResponseDto(reservedIds);
+    }
+
+    // 예약가능한 캠프사이트를 타입별로 하나씩 조회
+    @Transactional(readOnly = true)
+    public List<CampSiteResponseDto> getAvailableCampSites(ReservationCheckDateRequestDto requestDto) {
+
+        List<CampSite> campSites = reservationRepository.findAvailableCampSites(
+                requestDto.getCampId(),
+                requestDto.getCheckIn(),
+                requestDto.getCheckOut());
+
+        // 타입별 첫 번째 행 데이터만 가져오기
+        return campSites.stream()
+                .collect(Collectors.groupingBy(CampSite::getSiteType))
+                .values().stream()
+                .map(group -> group.get(0))
+                .map(campSiteMapper::toCampSiteResponseDto)
+                .toList();
     }
 }

--- a/src/main/java/site/campingon/campingon/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/site/campingon/campingon/reservation/service/ReservationServiceImpl.java
@@ -45,9 +45,9 @@ public class ReservationServiceImpl implements ReservationService {
 
     // 캠프사이트 선택 후 예약 요청
     @Transactional
-    public void createReservation(ReservationCreateRequestDto requestDto) {
+    public void createReservation(Long userId, ReservationCreateRequestDto requestDto) {
 
-        User user = reservationValidate.validateUserById(requestDto.getUserId());
+        User user = reservationValidate.validateUserById(userId);
         
         CampSite campSite = reservationValidate.validateCampSiteById(requestDto.getCampId());
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,4 +36,5 @@ jwt:
 app:
   pagination:
     reservation:
-      size: 10
+      page: 0
+      size: 5

--- a/src/test/java/site/campingon/campingon/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/site/campingon/campingon/reservation/service/ReservationServiceTest.java
@@ -146,7 +146,6 @@ class ReservationServiceTest {
 
         // given
         ReservationCreateRequestDto requestDto = new ReservationCreateRequestDto(
-            mockUser.getId(),
             mockCamp.getId(),
             mockCampSite.getId(),
             LocalDateTime.now(),
@@ -155,17 +154,17 @@ class ReservationServiceTest {
             50000
         );
 
-        when(reservationValidate.validateUserById(requestDto.getUserId()))
+        when(reservationValidate.validateUserById(mockUser.getId()))
             .thenReturn(mockUser);
         when(reservationValidate.validateCampSiteById(requestDto.getCampSiteId()))
             .thenReturn(mockCampSite);
 
         // when
-        reservationService.createReservation(requestDto);
+        reservationService.createReservation(mockUser.getId(), requestDto);
 
         // then
         verify(reservationRepository).save(any(Reservation.class));
-        verify(reservationValidate).validateUserById(requestDto.getUserId());
+        verify(reservationValidate).validateUserById(mockUser.getId());
         verify(reservationValidate).validateCampSiteById(requestDto.getCampSiteId());
     }
 
@@ -228,7 +227,6 @@ class ReservationServiceTest {
     void createReservationUserNotFound() {
         // given
         ReservationCreateRequestDto requestDto = new ReservationCreateRequestDto(
-            999L, // 존재하지 않는 유저 ID
             mockCamp.getId(),
             mockCampSite.getId(),
             LocalDateTime.now(),
@@ -237,12 +235,13 @@ class ReservationServiceTest {
             50000
         );
 
-        when(reservationValidate.validateUserById(requestDto.getUserId()))
+        Long wrongId = 999L; // 존재하지 않는 유저 ID
+        when(reservationValidate.validateUserById(wrongId))
             .thenThrow(new GlobalException(ErrorCode.USER_NOT_FOUND_BY_ID));
 
         // when & then
         assertThrows(GlobalException.class, () -> 
-            reservationService.createReservation(requestDto));
+            reservationService.createReservation(wrongId, requestDto));
         verify(reservationRepository, never()).save(any());
     }
 
@@ -251,7 +250,6 @@ class ReservationServiceTest {
     void createReservationCampSiteNotFound() {
         // given
         ReservationCreateRequestDto requestDto = new ReservationCreateRequestDto(
-            mockUser.getId(),
             mockCamp.getId(),
             mockCampSite.getId(),
             LocalDateTime.now(),
@@ -260,14 +258,14 @@ class ReservationServiceTest {
             50000
         );
 
-        when(reservationValidate.validateUserById(requestDto.getUserId()))
+        when(reservationValidate.validateUserById(mockUser.getId()))
             .thenReturn(mockUser);
         when(reservationValidate.validateCampSiteById(requestDto.getCampId()))
             .thenThrow(new GlobalException(ErrorCode.CAMP_NOT_FOUND_BY_ID));
 
         // when & then
         assertThrows(GlobalException.class, () -> 
-            reservationService.createReservation(requestDto));
+            reservationService.createReservation(mockUser.getId(), requestDto));
         verify(reservationRepository, never()).save(any());
     }
 

--- a/src/test/java/site/campingon/campingon/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/site/campingon/campingon/reservation/service/ReservationServiceTest.java
@@ -24,6 +24,7 @@ import site.campingon.campingon.reservation.repository.ReservationRepository;
 import site.campingon.campingon.reservation.utils.ReservationValidate;
 import site.campingon.campingon.user.entity.User;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -79,8 +80,8 @@ class ReservationServiceTest {
                 .user(mockUser)
                 .camp(mockCamp)
                 .campSite(mockCampSite)
-                .checkIn(LocalDateTime.now())
-                .checkOut(LocalDateTime.now().plusDays(1))
+                .checkInDate(LocalDate.from(LocalDateTime.now()))
+                .checkOutDate(LocalDate.from(LocalDateTime.now().plusDays(1)))
                 .guestCnt(2)
                 .status(ReservationStatus.RESERVED)
                 .totalPrice(50000)
@@ -104,8 +105,6 @@ class ReservationServiceTest {
                 .id(1L)
                 .userId(mockUser.getId())
                 .campSiteId(mockCampSite.getId())
-                .checkIn(mockReservation.getCheckIn())
-                .checkOut(mockReservation.getCheckOut())
                 .guestCnt(mockReservation.getGuestCnt())
                 .status(mockReservation.getStatus())
                 .totalPrice(mockReservation.getTotalPrice())
@@ -148,8 +147,8 @@ class ReservationServiceTest {
         ReservationCreateRequestDto requestDto = new ReservationCreateRequestDto(
             mockCamp.getId(),
             mockCampSite.getId(),
-            LocalDateTime.now(),
-            LocalDateTime.now().plusDays(1),
+            LocalDate.now(),
+            LocalDate.now().plusDays(1),
             2,
             50000
         );
@@ -198,8 +197,8 @@ class ReservationServiceTest {
         // given
         ReservationCheckDateRequestDto requestDto = new ReservationCheckDateRequestDto(
             mockCamp.getId(),
-            LocalDateTime.now(),
-            LocalDateTime.now().plusDays(1)
+            LocalDate.now(),
+            LocalDate.now().plusDays(1)
         );
 
         List<Long> reservedIds = Arrays.asList(2L, 3L);
@@ -229,8 +228,8 @@ class ReservationServiceTest {
         ReservationCreateRequestDto requestDto = new ReservationCreateRequestDto(
             mockCamp.getId(),
             mockCampSite.getId(),
-            LocalDateTime.now(),
-            LocalDateTime.now().plusDays(1),
+            LocalDate.now(),
+            LocalDate.now().plusDays(1),
             2,
             50000
         );
@@ -252,8 +251,8 @@ class ReservationServiceTest {
         ReservationCreateRequestDto requestDto = new ReservationCreateRequestDto(
             mockCamp.getId(),
             mockCampSite.getId(),
-            LocalDateTime.now(),
-            LocalDateTime.now().plusDays(1),
+            LocalDate.now(),
+            LocalDate.now().plusDays(1),
             2,
             50000
         );


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

예약 가능한 캠프사이트 조회 api 통합

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] 이미예약된 캠프사이트 조회 후 -> 예약가능한 캠프사이트 조회하는 api가 2개로 분리되어 있던 것을 합친 api 생성
- [x] `ReservationController.getAvailableCampSites()`
- [x] 체크인, 체크아웃은 고정시간이라서 상수로 관리하려고 ENUM 생성

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- `ReservationController.getReservedCampSiteIds()` + `CampSiteController.getAvailableCampSites()` 의 조합으로 예약 가능한 캠프사이트를 조회하는 로직이었는데, `ReservationController.getAvailableCampSites()` 하나만 사용해도 됨
- 엔드포인트 url은 **api/reservations/available**
- 체크인아웃 날짜와 시간 필드를 분리, ERD 수정도 완료


## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [x] 테스트 케이스 작성
2. [ ] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.


## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.
<img width="411" alt="image" src="https://github.com/user-attachments/assets/ba5e8ab8-2212-4b19-b63f-400a1fd6abd8">


## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #139 