### PR TITLE
Feat: #149 권한별 Path 설정

### DIFF
--- a/src/main/java/site/campingon/campingon/common/config/SecurityConfig.java
+++ b/src/main/java/site/campingon/campingon/common/config/SecurityConfig.java
@@ -60,8 +60,11 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/","/h2-console/**").permitAll()
-                        .anyRequest().permitAll());
+                        .requestMatchers(SecurityPath.ADMIN_ENDPOINTS).hasRole("ADMIN")
+                        .requestMatchers(SecurityPath.USER_ENDPOINTS).hasRole("USER")
+                        .requestMatchers(SecurityPath.PUBLIC_ENDPOINTS).permitAll()
+                        .anyRequest().authenticated()
+                );
 
         // JwtFilter 추가
         http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, objectMapper), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/site/campingon/campingon/common/config/SecurityConfig.java
+++ b/src/main/java/site/campingon/campingon/common/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                         .requestMatchers(SecurityPath.ADMIN_ENDPOINTS).hasRole("ADMIN")
                         .requestMatchers(SecurityPath.USER_ENDPOINTS).hasRole("USER")
                         .requestMatchers(SecurityPath.PUBLIC_ENDPOINTS).permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 );
 
         // JwtFilter 추가

--- a/src/main/java/site/campingon/campingon/common/config/SecurityPath.java
+++ b/src/main/java/site/campingon/campingon/common/config/SecurityPath.java
@@ -25,6 +25,9 @@ public class SecurityPath {
     public static final String[] ADMIN_ENDPOINTS = {
         "/api/camps/*/toggle-availability",
         "/api/admin/camps/**",
-        "/api/keywords/**"
+        "/api/keywords/**",
+        "/api/basedList/**",
+        "/api/imageList/**"
+
     };
 }

--- a/src/main/java/site/campingon/campingon/common/config/SecurityPath.java
+++ b/src/main/java/site/campingon/campingon/common/config/SecurityPath.java
@@ -1,0 +1,30 @@
+package site.campingon.campingon.common.config;
+
+public class SecurityPath {
+
+    // permitAll
+    public static final String[] PUBLIC_ENDPOINTS = {
+        "/api/signup",
+        "/api/login",
+        "/api/logout",
+        "/api/token/refresh",
+        "/api/users/check-duplicate",
+        "/"
+    };
+
+
+    // hasRole("USER")
+    public static final String[] USER_ENDPOINTS = {
+        "/api/camps/**",
+        "/api/users/me/*",
+        "/api/reservations/**",
+        "/api/camps/*/bookmarks"
+    };
+
+    // hasRole("ADMIN")
+    public static final String[] ADMIN_ENDPOINTS = {
+        "/api/camps/*/toggle-availability",
+        "/api/admin/camps/**",
+        "/api/keywords/**"
+    };
+}

--- a/src/main/java/site/campingon/campingon/user/entity/User.java
+++ b/src/main/java/site/campingon/campingon/user/entity/User.java
@@ -77,18 +77,6 @@ public class User extends BaseEntity {
 
     @Override
     public String toString() {
-        int maxKeywordsToShow = 3; // 출력할 최대 항목 수
-        String keywordsSummary = keywords.stream()
-            .limit(maxKeywordsToShow) // 최대 3개만 선택
-            .map(UserKeyword::toString) // 각 항목을 문자열로 변환
-            .toList()
-            .toString();
-
-        // 추가로 더 많은 키워드가 있는 경우 처리
-        if (keywords.size() > maxKeywordsToShow) {
-            keywordsSummary = keywordsSummary.substring(0, keywordsSummary.length() - 1) // 마지막 ']' 제거
-                + ", ... (" + (keywords.size() - maxKeywordsToShow) + " more)]"; // 추가된 항목 표시
-        }
 
         return "[User(" +
             "id=" + id +
@@ -100,7 +88,6 @@ public class User extends BaseEntity {
             ", deleteReason=" + deleteReason +
             ", deletedAt=" + deletedAt +
             ", role=" + role +
-            ", keywords=" + keywordsSummary +
             ")]";
     }
 }


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

보안 설정에서 permitAll 경로를 개별적으로 설정하는 대신 별도의 리스트로 분리하여 클래스에서 관리


## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] PUBLIC / USER / ADMIN으로 분리

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.
- api 명세서 보고 작성했는데 좀 고쳐야 할 부분이 있어보입니다. 의논해야 할 것 같아요
- 지금 정해지지 않은 다른 엔드포인트들에 대해서는 `permitAll`로 설정해놨는데 나중에 변경해야할 것 같아요
  `authenticated`로 설정해 두니까 고캠핑/필터링/imageList 같은 경우에 제대로 동작을 안하더라구요(포스트맨에서)
- User 혹은 Admin일 때는 postman / react에서 반드시 accessToken을 포함시켜주세요

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- 엔드포인트별 분류한 SecurityPath 클래스 추가
- SecurityConfig에 각 Path별로 권한 분리
- Keywords도 Lazy Loading 객체라 ToString에서 오류 나길래 제거했습니다.

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트(Postman)
3. [ ] 기타:



## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #149