### PR TITLE
Imporove: 캠핑장 인기 목록 조회 페이지 별 크기 고정과 MogoDB 연결 설정

### DIFF
--- a/src/main/java/site/campingon/campingon/camp/controller/CampController.java
+++ b/src/main/java/site/campingon/campingon/camp/controller/CampController.java
@@ -10,8 +10,6 @@ import org.springframework.web.bind.annotation.*;
 import site.campingon.campingon.camp.dto.CampDetailResponseDto;
 import site.campingon.campingon.camp.dto.CampListResponseDto;
 import site.campingon.campingon.camp.service.CampService;
-import site.campingon.campingon.common.exception.ErrorCode;
-import site.campingon.campingon.common.exception.GlobalException;
 import site.campingon.campingon.common.jwt.CustomUserDetails;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,10 +23,6 @@ import site.campingon.campingon.user.repository.UserKeywordRepository;
 public class CampController {
 
   private final CampService campService;
-  private final UserKeywordRepository userKeywordRepository;
-
-  private static final int DEFAULT_PAGE_SIZE = 12;
-  private static final int KEYWORD_MATCHED_PAGE_SIZE = 9;
 
   // 사용자 키워드 맞춤 캠핑장 목록 조회 (페이지네이션 - 횡스크롤)
   @GetMapping("/matched")
@@ -46,25 +40,12 @@ public class CampController {
   @GetMapping("/popular")
   public ResponseEntity<Page<CampListResponseDto>> getPopularCamps(
       @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "9") int size,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-    // 인증 상태 검증
-    if (userDetails == null) {
-      throw new GlobalException(ErrorCode.ACCESS_DENIED);
-    }
-
-    Long userId = userDetails.getId();
-    if (userId == null) {
-      throw new GlobalException(ErrorCode.USER_NOT_FOUND_BY_ID);
-    }
-
-    // 사용자 키워드 기반으로 페이지 크기 결정
-    boolean hasKeywords = userKeywordRepository.existsByUserId(userId);
-    int pageSize = hasKeywords ? KEYWORD_MATCHED_PAGE_SIZE : DEFAULT_PAGE_SIZE;
-
-    // 인기 캠핑장 조회
+    Long userId = userDetails != null ? userDetails.getId() : null;
     return ResponseEntity.ok(
-        campService.getPopularCamps(userId, PageRequest.of(page, pageSize))
+        campService.getPopularCamps(userId, PageRequest.of(page, size))
     );
   }
 

--- a/src/main/java/site/campingon/campingon/camp/dto/CampListResponseDto.java
+++ b/src/main/java/site/campingon/campingon/camp/dto/CampListResponseDto.java
@@ -16,7 +16,7 @@ public class CampListResponseDto {
   private String lineIntro;
   private String thumbImage;
 
-  private String address;  // 도로명 주소
+  private String streetAddr;  // 도로명 주소
 
   private List<String> keywords;   // 캠핑장 키워드
 

--- a/src/main/java/site/campingon/campingon/camp/dto/CampSiteListResponseDto.java
+++ b/src/main/java/site/campingon/campingon/camp/dto/CampSiteListResponseDto.java
@@ -16,7 +16,7 @@ public class CampSiteListResponseDto {
   private Integer maximumPeople;
   private Integer price;
   private Induty siteType;
-  private String indoor_facility;
+  private String indoorFacility;
 
   @Builder.Default  // 기본값 자동 설정
   private LocalTime checkInTime = LocalTime.of(15, 0);  // 15:00

--- a/src/main/java/site/campingon/campingon/camp/service/CampService.java
+++ b/src/main/java/site/campingon/campingon/camp/service/CampService.java
@@ -9,13 +9,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.campingon.campingon.camp.dto.CampDetailResponseDto;
 import site.campingon.campingon.camp.dto.CampListResponseDto;
-import site.campingon.campingon.camp.dto.CampSiteListResponseDto;
 import site.campingon.campingon.camp.entity.Camp;
-import site.campingon.campingon.camp.entity.CampInduty;
-import site.campingon.campingon.camp.entity.CampSite;
 import site.campingon.campingon.camp.mapper.CampMapper;
 import site.campingon.campingon.camp.repository.CampRepository;
-import site.campingon.campingon.camp.repository.CampSiteRepository;
 import site.campingon.campingon.bookmark.repository.BookmarkRepository;
 import site.campingon.campingon.common.exception.ErrorCode;
 import site.campingon.campingon.common.exception.GlobalException;
@@ -57,7 +53,9 @@ public class CampService {
     return campRepository.findPopularCamps(pageable)
         .map(camp -> {
           CampListResponseDto dto = campMapper.toCampListDto(camp);
-          dto.setMarked(bookMarkRepository.existsByCampIdAndUserId(camp.getId(), userId));
+          if (userId != null) {
+            dto.setMarked(bookMarkRepository.existsByCampIdAndUserId(camp.getId(), userId));
+          }
           return dto;
         });
   }

--- a/src/main/java/site/campingon/campingon/user/repository/UserKeywordRepository.java
+++ b/src/main/java/site/campingon/campingon/user/repository/UserKeywordRepository.java
@@ -12,5 +12,4 @@ import java.util.List;
 public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> {
   @Query("SELECT k.keyword FROM UserKeyword k WHERE k.user.id = :userId")
   List<String> findKeywordsByUserId(@Param("userId")Long userId);
-  boolean existsByUserId(Long userId);  // 키워드 존재 여부 확인
 }


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.
인기(추천수가 많은)있는 캠핑장을 9개로 고정해서 페이지네이션 적용 

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- 페이지 크기를 9개씩으로 제한하여 가져올 수 있도록 수정하고 사용자의 인증없이 작동할 수 있도록 작성하였으나, 사용자별 인증의 경우에는 개인의 북마크 표시를 확인을 위해 인증 필요하여 다시 인증을 요구하도록 수정 
- MongoDB관련 application.yml 작성
- @Document 데이터 작성

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- CampController, CampService getPopular 메서드 수정
- application.yml  data: mongoDB 설정 추가
- 현재 Network Access 모두 접근 가능으로 수정 
- Camp도메인의 각 패키지 별 mongoDB 디렉터리 생성 후 기능 구현 
- SearchInfo Collections의 @Document 작성 
- SecurityPath의 검색 엔드포인드 추가 

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [x] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.
![image](https://github.com/user-attachments/assets/99780eee-600b-45fb-af4f-d3a7dd939357)


## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #156, Closes #157 