### PR TITLE
Fix/#213 CampMapper에 위도, 경도 추가

### DIFF
--- a/src/main/java/site/campingon/campingon/camp/mapper/CampMapper.java
+++ b/src/main/java/site/campingon/campingon/camp/mapper/CampMapper.java
@@ -73,6 +73,8 @@ public interface CampMapper {
             .zipcode(campAddr.getZipcode())
             .streetAddr(campAddr.getStreetAddr())
             .detailedAddr(campAddr.getDetailedAddr())
+            .latitude(campAddr.getLocation().getY())
+            .longitude(campAddr.getLocation().getX())
             .build();
   }
 


### PR DESCRIPTION
## 📌 목적
- 고캠핑의 캠핑장 위도와 경도를 활용하여 캠핑장 상세 페이지에 카카오맵 지도를 표시하기 위해

## 🛠️ 작업 상세 내용
- 위도와 경도 추가