### PR TITLE
Refactor/#215 camp 예약확인을 위한 캠핑지 조회시 반환 데이터 추가

### DIFF
--- a/src/main/java/site/campingon/campingon/camp/controller/CampSiteController.java
+++ b/src/main/java/site/campingon/campingon/camp/controller/CampSiteController.java
@@ -9,6 +9,8 @@ import site.campingon.campingon.camp.dto.CampSiteListResponseDto;
 import site.campingon.campingon.camp.dto.CampSiteResponseDto;
 import site.campingon.campingon.camp.service.CampSiteReserveService;
 import site.campingon.campingon.camp.service.CampSiteService;
+import site.campingon.campingon.common.exception.ErrorCode;
+import site.campingon.campingon.common.exception.GlobalException;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -35,13 +37,29 @@ public class CampSiteController {
                                                                                @DateTimeFormat(pattern = "yyyy-MM-dd")
                                                                                LocalDate checkout) {
 
+        if (checkin == null || checkout == null) {
+            throw new GlobalException(ErrorCode.REQUIRED_RESERVATION_DATE);
+        }
+
         return ResponseEntity.ok(campSiteReserveService.getAvailableCampSites(campId, checkin, checkout));
     }
 
-    // 특정 캠핑지 조회
+    // 예약확인을 위한 캠핑지 조회
     @GetMapping("/{campId}/sites/{siteId}")
     public ResponseEntity<CampSiteResponseDto> getCampSite(@PathVariable("campId") Long campId,
-                                                           @PathVariable("siteId") Long siteId) {
+                                                           @PathVariable("siteId") Long siteId,
+
+                                                           @RequestParam(value = "checkin")
+                                                           @DateTimeFormat(pattern = "yyyy-MM-dd")
+                                                           LocalDate checkin,
+
+                                                           @RequestParam(value = "checkout")
+                                                           @DateTimeFormat(pattern = "yyyy-MM-dd")
+                                                           LocalDate checkout) {
+
+        if (checkin == null || checkout == null) {
+            throw new GlobalException(ErrorCode.REQUIRED_RESERVATION_DATE);
+        }
 
         return ResponseEntity.ok(campSiteService.getCampSite(campId, siteId));
     }

--- a/src/main/java/site/campingon/campingon/camp/dto/CampAddrDto.java
+++ b/src/main/java/site/campingon/campingon/camp/dto/CampAddrDto.java
@@ -10,12 +10,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CampAddrDto {
-    private Long campAddrId;    // 주소 ID
-    private String city;        // 도/광역시
-    private String state;       // 시/군/구
-    private String zipcode;     // 우편번호
-    private String streetAddr;  // 도로명 주소
-    private String detailedAddr;// 상세 주소
-    private double latitude;    // 위도
-    private double longitude;   // 경도
+    private Long campAddrId;
+    private String city;
+    private String state;
+    private String zipcode;
+    private String streetAddr;
+    private String detailedAddr;
+    private double latitude;
+    private double longitude;
 }

--- a/src/main/java/site/campingon/campingon/camp/dto/CampDetailResponseDto.java
+++ b/src/main/java/site/campingon/campingon/camp/dto/CampDetailResponseDto.java
@@ -15,13 +15,13 @@ public class CampDetailResponseDto {
   private String tel;
   private String intro;
   private String lineIntro;
-  private String homepage;   // 홈페이지 사용 고려
-  private String outdoorFacility;   // 부대시설
-  private List<String> indutys;  // 업종
+  private String homepage;
+  private String outdoorFacility;
+  private List<String> indutys;
 
-  private CampAddrDto campAddr;  // 경도, 위도, 도로명 주소
+  private CampAddrDto campAddr;
 
   private List<String> images;   // 캠핑장 이미지(썸네일 포함) <- Camp_image 엔티티
 
-  private CampInfoDto campInfo;  // 추천 수, 찜 수
+  private CampInfoDto campInfo;
 }

--- a/src/main/java/site/campingon/campingon/camp/dto/CampInfoDto.java
+++ b/src/main/java/site/campingon/campingon/camp/dto/CampInfoDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CampInfoDto {
-    private Long campInfoId;      // 캠프 정보 ID
-    private Integer recommendCnt; // 추천 수
-    private Integer bookmarkCnt;  // 찜 수
+    private Long campInfoId;
+    private Integer recommendCnt;
+    private Integer bookmarkCnt;
 }

--- a/src/main/java/site/campingon/campingon/camp/dto/CampSimpleDto.java
+++ b/src/main/java/site/campingon/campingon/camp/dto/CampSimpleDto.java
@@ -1,0 +1,22 @@
+package site.campingon.campingon.camp.dto;
+
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CampSimpleDto {
+
+    private Long campId;
+
+    private String campName;
+
+    private String city;
+
+    private String state;
+
+    private String streetAddr;
+
+}

--- a/src/main/java/site/campingon/campingon/camp/dto/CampSiteListResponseDto.java
+++ b/src/main/java/site/campingon/campingon/camp/dto/CampSiteListResponseDto.java
@@ -7,8 +7,8 @@ import site.campingon.campingon.reservation.entity.CheckTime;
 
 import java.time.LocalTime;
 
+@ToString
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/site/campingon/campingon/camp/dto/CampSiteResponseDto.java
+++ b/src/main/java/site/campingon/campingon/camp/dto/CampSiteResponseDto.java
@@ -6,21 +6,22 @@ import site.campingon.campingon.reservation.entity.CheckTime;
 
 import java.time.LocalTime;
 
+@ToString
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Data
 public class CampSiteResponseDto {
     private Long siteId;
     private Integer maximumPeople;
     private Integer price;
-    private String indoorFacility;
     private Induty siteType;
-    private boolean isAvailable;
+    private String indoorFacility;
 
     @Builder.Default
     private CheckTime checkinTime = CheckTime.CHECKIN;
     @Builder.Default
     private CheckTime checkoutTime = CheckTime.CHECKOUT;
+
+    CampSimpleDto campSimpleDto;
 }

--- a/src/main/java/site/campingon/campingon/camp/mapper/CampSiteMapper.java
+++ b/src/main/java/site/campingon/campingon/camp/mapper/CampSiteMapper.java
@@ -12,6 +12,11 @@ import site.campingon.campingon.camp.entity.CampSite;
 public interface CampSiteMapper {
 
     @Mapping(target = "siteId", source = "id")
+    @Mapping(target = "campSimpleDto.campId", source = "camp.id")
+    @Mapping(target = "campSimpleDto.campName", source = "camp.campName")
+    @Mapping(target = "campSimpleDto.city", source = "camp.campAddr.city")
+    @Mapping(target = "campSimpleDto.state", source = "camp.campAddr.state")
+    @Mapping(target = "campSimpleDto.streetAddr", source = "camp.campAddr.streetAddr")
     CampSiteResponseDto toCampSiteResponseDto(CampSite campSite);
 
     @Mapping(target = "siteId", source = "id")

--- a/src/main/java/site/campingon/campingon/common/config/SecurityConfig.java
+++ b/src/main/java/site/campingon/campingon/common/config/SecurityConfig.java
@@ -21,7 +21,7 @@ import site.campingon.campingon.common.oauth.service.CustomOAuth2UserService;
 import site.campingon.campingon.common.jwt.CustomUserDetailsService;
 import site.campingon.campingon.common.jwt.JwtAuthenticationFilter;
 import site.campingon.campingon.common.jwt.JwtTokenProvider;
-import site.campingon.campingon.common.oauth.handler.CustomOAuthSuccessHandler;
+import site.campingon.campingon.common.oauth.handler.CustomOAuth2SuccessHandler;
 
 @Configuration
 @EnableWebSecurity
@@ -30,7 +30,7 @@ import site.campingon.campingon.common.oauth.handler.CustomOAuthSuccessHandler;
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
-    private final CustomOAuthSuccessHandler customOAuthSuccessHandler;
+    private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
     private final CustomOAuth2FailureHandler customOAuthFailureHandler;
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
@@ -55,7 +55,7 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
                                 .userService(customOAuth2UserService))
 //                        .defaultSuccessUrl("/oauth/success") // 로그인 성공시 이동할 URL
-                        .successHandler(customOAuthSuccessHandler)
+                        .successHandler(customOAuth2SuccessHandler)
 //                        .failureUrl("/oauth/fail") // 로그인 실패시 이동할 URL
                         .failureHandler(customOAuthFailureHandler))
                 .logout(logout -> logout.logoutSuccessUrl("/oauth/logout") // 로그아웃 성공시 해당 url로 이동

--- a/src/main/java/site/campingon/campingon/common/exception/ErrorCode.java
+++ b/src/main/java/site/campingon/campingon/common/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     CAMP_NOT_FOUND(HttpStatus.NOT_FOUND, "CAMP-002", "캠핑장을 찾을 수 없습니다."),
 
     CAMPSITE_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "CAMPSITE-001", "캠핑지의 ID를 찾을 수 없습니다."),
+    REQUIRED_RESERVATION_DATE(HttpStatus.BAD_REQUEST, "CAMPSITE-002", "예약일자를 선택하지 않았습니다."),
 
     REVIEW_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "REVIEW-001", "해당 리뷰를 찾을 수 없습니다."),
     REVIEW_NOT_IN_CAMP(HttpStatus.NOT_FOUND, "REVIEW-002", "리뷰가 해당 캠프에 속하지 않습니다."),

--- a/src/main/java/site/campingon/campingon/common/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/site/campingon/campingon/common/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
-public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;

--- a/src/main/java/site/campingon/campingon/reservation/dto/CampAddrResponseDto.java
+++ b/src/main/java/site/campingon/campingon/reservation/dto/CampAddrResponseDto.java
@@ -4,7 +4,7 @@ import lombok.*;
 
 @Getter
 @ToString
-@Builder(toBuilder = true)
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class CampAddrResponseDto {

--- a/src/main/java/site/campingon/campingon/reservation/dto/CampResponseDto.java
+++ b/src/main/java/site/campingon/campingon/reservation/dto/CampResponseDto.java
@@ -4,7 +4,7 @@ import lombok.*;
 
 @Getter
 @ToString
-@Builder(toBuilder = true)
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class CampResponseDto {

--- a/src/main/java/site/campingon/campingon/reservation/dto/CampSiteResponseDto.java
+++ b/src/main/java/site/campingon/campingon/reservation/dto/CampSiteResponseDto.java
@@ -5,7 +5,7 @@ import site.campingon.campingon.camp.entity.Induty;
 
 @Getter
 @ToString
-@Builder(toBuilder = true)
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class CampSiteResponseDto {

--- a/src/main/java/site/campingon/campingon/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/site/campingon/campingon/reservation/dto/ReservationResponseDto.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 
 @Getter
 @ToString
-@Builder(toBuilder = true)
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReservationResponseDto {


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

예약확인을 위한 캠핑지 조회시 반환 데이터 추가

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] 불필요한 주석 제거, response에 tobuilder 제거
- [x] 예약일자 파라미터 없을 시에 대한 예외처리
- [x] 예약확인을위한 간략한 캠프 정보를 담은 CampSimpleDto 생성

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- camp dto 필드설명 주석 제거
- camp response의 tobuilder = true 제거
- reservation response의 tobuilder = true 제거

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.
<img width="697" alt="image" src="https://github.com/user-attachments/assets/963861dd-fa6e-4155-bb50-b222239ee907">

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #215 Closes #220