### PR TITLE
Feat: #248 키워드 관련 서비스 로직 및 api 추가

### DIFF
--- a/src/main/java/site/campingon/campingon/camp/repository/mongodb/MongoRecommendClient.java
+++ b/src/main/java/site/campingon/campingon/camp/repository/mongodb/MongoRecommendClient.java
@@ -13,7 +13,6 @@ import site.campingon.campingon.camp.dto.mongodb.SearchResultDto;
 import site.campingon.campingon.camp.entity.mongodb.SearchInfo;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -54,9 +53,10 @@ public class MongoRecommendClient {
         String matchCountStage = "{$addFields: {" +
             "matchCount: {" +
                 "$size: {" +
-                    "$setIntersection: [" +
-                        "$hashtags," +
-                        Arrays.toString(userKeywords.toArray()) +
+            "$setIntersection: [\"$hashtags\", " +
+                    "[" + userKeywords.stream()
+                    .map(keyword -> "\"" + keyword + "\"")
+                    .collect(Collectors.joining(", ")) + "]" +
                     "]" +
                 "}" +
             "}" +

--- a/src/main/java/site/campingon/campingon/camp/service/mongodb/SearchInfoService.java
+++ b/src/main/java/site/campingon/campingon/camp/service/mongodb/SearchInfoService.java
@@ -38,7 +38,7 @@ public class SearchInfoService {
 
         // 사용자 키워드 조회 (검색 조건이 있을 때만 사용됨)
         List<String> userKeywords = userId != 0L ?
-            userService.getKeywordsByUserId(userId) :
+            userService.getKeywordsByUserId(userId).getKeywords() :
             new ArrayList<>();
 
         // 검색 수행 (결과와 전체 개수를 한 번에 조회)
@@ -69,7 +69,7 @@ public class SearchInfoService {
     public Page<CampListResponseDto> getMatchedCampsByKeywords(
         String username, Long userId, Pageable pageable) {
         // 사용자 키워드 조회
-        List<String> userKeywords = userService.getKeywordsByUserId(userId);
+        List<String> userKeywords = userService.getKeywordsByUserId(userId).getKeywords();
 
         if (userKeywords.isEmpty()) {
             return Page.empty(pageable);

--- a/src/main/java/site/campingon/campingon/common/config/SecurityPath.java
+++ b/src/main/java/site/campingon/campingon/common/config/SecurityPath.java
@@ -11,8 +11,7 @@ public class SecurityPath {
         "/",
         "/api/mongo/camps/search",
         "/api/camps/*/available",
-        "/api/camps/*",
-        "/api/keywords"
+        "/api/camps/*"
     };
 
 
@@ -24,13 +23,14 @@ public class SecurityPath {
         "/api/users/me",
         "/api/reservations/**",
         "/api/camps/*/bookmarks",
-        "/api/logout"
+        "/api/logout",
+        "/api/keywords",
+        "/api/keywords/me"
     };
 
     // hasRole("ADMIN")
     public static final String[] ADMIN_ENDPOINTS = {
         "/api/admin/**",
-        "/api/keywords/**",
         "/api/basedList/**",
         "/api/imageList/**"
 

--- a/src/main/java/site/campingon/campingon/common/exception/ErrorCode.java
+++ b/src/main/java/site/campingon/campingon/common/exception/ErrorCode.java
@@ -57,7 +57,10 @@ public enum ErrorCode {
 
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE-005", "요청한 파일을 찾을 수 없습니다."),
     S3_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-006", "S3 작업 중 오류가 발생했습니다."),
-    FILE_MOVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-007", "파일 이동 중 오류가 발생했습니다.");
+    FILE_MOVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-007", "파일 이동 중 오류가 발생했습니다."),
+
+    // 키워드 찾을 수 없음
+    KEYWORD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "KEYWORD-001", "키워드는 최대 5개까지만 등록 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/site/campingon/campingon/user/controller/UserController.java
+++ b/src/main/java/site/campingon/campingon/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package site.campingon.campingon.user.controller;
 
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -80,14 +79,6 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    // 개인 키워드 목록 조회
-    @GetMapping("/users/me/keywords")
-    public ResponseEntity<List<String>> getMyKeyword(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getId();
-        return ResponseEntity.ok(userService.getKeywordsByUserId(userId));
-    }
 
-
-    // TODO: 회원 정보 조회(다른 사용자의 정보 조회)
 
 }

--- a/src/main/java/site/campingon/campingon/user/controller/UserKeywordController.java
+++ b/src/main/java/site/campingon/campingon/user/controller/UserKeywordController.java
@@ -1,0 +1,58 @@
+package site.campingon.campingon.user.controller;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.campingon.campingon.common.jwt.CustomUserDetails;
+import site.campingon.campingon.user.dto.KeywordRequestDto;
+import site.campingon.campingon.user.dto.KeywordResponseDto;
+import site.campingon.campingon.user.entity.KeywordEnum;
+import site.campingon.campingon.user.service.UserService;
+
+@RestController
+@RequestMapping("/api/keywords")
+@RequiredArgsConstructor
+public class UserKeywordController {
+
+    private final UserService userService;
+
+    // 선택할 키워드 목록 조회
+    @GetMapping
+    public ResponseEntity<KeywordResponseDto> getAvailableKeywords() {
+        // Enum에서 displayName 값 추출
+        List<String> keywords = Arrays.stream(KeywordEnum.values())
+            .map(KeywordEnum::getDisplayName)
+            .collect(Collectors.toList());
+        return ResponseEntity.ok(new KeywordResponseDto(keywords));
+    }
+
+
+    // 개인 키워드 목록 조회
+    @GetMapping("/me")
+    public ResponseEntity<KeywordResponseDto> getMyKeyword(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getId();
+        return ResponseEntity.ok(userService.getKeywordsByUserId(userId));
+    }
+
+    // 선택한 키워드 목록 저장
+    @PostMapping("/me")
+    public ResponseEntity<Void> replaceKeywords(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @RequestBody KeywordRequestDto keywordRequest
+    ) {
+        Long userId = userDetails.getId();
+        List<String> keywords = keywordRequest.getKeywords();
+        userService.replaceKeywords(userId, keywords);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+}

--- a/src/main/java/site/campingon/campingon/user/dto/KeywordRequestDto.java
+++ b/src/main/java/site/campingon/campingon/user/dto/KeywordRequestDto.java
@@ -1,0 +1,9 @@
+package site.campingon.campingon.user.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class KeywordRequestDto {
+    private List<String> keywords;
+}

--- a/src/main/java/site/campingon/campingon/user/dto/KeywordResponseDto.java
+++ b/src/main/java/site/campingon/campingon/user/dto/KeywordResponseDto.java
@@ -1,0 +1,13 @@
+package site.campingon.campingon.user.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class KeywordResponseDto {
+
+    private List<String> keywords;
+
+}

--- a/src/main/java/site/campingon/campingon/user/entity/KeywordEnum.java
+++ b/src/main/java/site/campingon/campingon/user/entity/KeywordEnum.java
@@ -1,0 +1,29 @@
+package site.campingon.campingon.user.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum KeywordEnum {
+    HOT_WATER_PROVIDED("온수 잘 나오는"),
+    HEALING("힐링"),
+    FRIENDLY("친절한"),
+    STAR_VIEWING("별 보기 좋은"),
+    COUPLE("커플"),
+    LOTS_OF_SHADE("그늘이 많은"),
+    FAMILY("가족"),
+    SWIMMING("물놀이 하기 좋은"),
+    OCEAN_VIEW("바다가 보이는"),
+    GOOD_FOR_KIDS("아이들 놀기 좋은"),
+    RELAXING("여유있는"),
+    CLEAN("깨끗한"),
+    EASY_CAR_PARKING("차대기 편한"),
+    FUN("재미있는"),
+    WIDE_SITE_SPACING("사이트 간격이 넓은");
+
+    private final String displayName;
+
+    KeywordEnum(String displayName) {
+        this.displayName = displayName;
+    }
+
+}

--- a/src/main/java/site/campingon/campingon/user/repository/UserKeywordRepository.java
+++ b/src/main/java/site/campingon/campingon/user/repository/UserKeywordRepository.java
@@ -1,5 +1,6 @@
 package site.campingon.campingon.user.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,4 +13,8 @@ import java.util.List;
 public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> {
   @Query("SELECT k.keyword FROM UserKeyword k WHERE k.user.id = :userId")
   List<String> findKeywordsByUserId(@Param("userId")Long userId);
+
+
+  @Query("SELECT k FROM UserKeyword k WHERE k.user.id = :userId AND k.keyword = :keyword")
+  Optional<UserKeyword> findByUserIdAndKeyword(@Param("keyword")String keyword, @Param("userId")Long userId);
 }

--- a/src/main/java/site/campingon/campingon/user/service/UserService.java
+++ b/src/main/java/site/campingon/campingon/user/service/UserService.java
@@ -11,12 +11,14 @@ import org.springframework.transaction.annotation.Transactional;
 import site.campingon.campingon.common.exception.ErrorCode;
 import site.campingon.campingon.common.exception.GlobalException;
 import site.campingon.campingon.common.jwt.RefreshTokenService;
+import site.campingon.campingon.user.dto.KeywordResponseDto;
 import site.campingon.campingon.user.dto.UserResponseDto;
 import site.campingon.campingon.user.dto.UserSignUpRequestDto;
 import site.campingon.campingon.user.dto.UserSignUpResponseDto;
 import site.campingon.campingon.user.dto.UserUpdateRequestDto;
 import site.campingon.campingon.user.entity.Role;
 import site.campingon.campingon.user.entity.User;
+import site.campingon.campingon.user.entity.UserKeyword;
 import site.campingon.campingon.user.mapper.UserMapper;
 import site.campingon.campingon.user.repository.UserKeywordRepository;
 import site.campingon.campingon.user.repository.UserRepository;
@@ -149,9 +151,45 @@ public class UserService {
         };
     }
 
-    // 키워드 조회
-    public List<String> getKeywordsByUserId(Long userId) {
-        return userKeywordRepository.findKeywordsByUserId(userId);
+    // 나의 키워드 조회
+    @Transactional(readOnly = true)
+    public KeywordResponseDto getKeywordsByUserId(Long userId) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND_BY_ID));
+
+        List<String> userKeywords = user.getKeywords().stream()
+            .map(UserKeyword::getKeyword)
+            .toList();
+
+        log.debug("회원 키워드 조회 - 유저 ID: {}, 키워드: {}", userId, userKeywords);
+        return new KeywordResponseDto(userKeywords);
     }
+
+    @Transactional
+    public void replaceKeywords(Long userId, List<String> keywords) {
+        // Validate keyword size (optional, assuming max 5)
+        if (keywords.size() > 5) {
+            throw new GlobalException(
+                ErrorCode.KEYWORD_LIMIT_EXCEEDED); // Custom error for exceeding limit
+        }
+
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND_BY_ID));
+
+        // 기존 키워드 제거
+        user.getKeywords().clear();
+
+        // 새 키워드 추가
+        for (String keyword : keywords) {
+            UserKeyword newKeyword = UserKeyword.builder()
+                .user(user)
+                .keyword(keyword)
+                .build();
+            userKeywordRepository.save(newKeyword);
+        }
+
+        log.info("회원 키워드 갱신 - 유저 ID: {}, 새 키워드 목록: {}", userId, keywords);
+    }
+
 
 }


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

키워드 관련 서비스 로직 및 api 추가


## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] 개인 키워드 등록
- [x] 개인 키워드 조회
- [x] 전체 키워드 목록 조회
- [x] DTO 사용으로 영향받은 MongoDB쪽 코드 일부 수정
- [x] 에러코드 추가 및 개인 키워드 목록 Enum으로 추가 -> 추후에 KeywordCode 등으로 관리하면 좋을 것 같아요
## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- DTO 사용으로 List로 반환 받았던 부분 getKeywords로 변경

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #248