### PR TITLE
fix: #260 구글유저의 재가입 버그 해결

### DIFF
--- a/src/main/java/site/campingon/campingon/common/jwt/CustomUserDetails.java
+++ b/src/main/java/site/campingon/campingon/common/jwt/CustomUserDetails.java
@@ -17,6 +17,7 @@ public class CustomUserDetails implements UserDetails, CustomUserPrincipal {
     private final Role role;
     private final String password;
     private final String name;
+    private final String oauthName = null;
 
     public CustomUserDetails(Long id, String email, String nickname, Role role, String password, String name) {
         this.id = id;

--- a/src/main/java/site/campingon/campingon/common/jwt/CustomUserPrincipal.java
+++ b/src/main/java/site/campingon/campingon/common/jwt/CustomUserPrincipal.java
@@ -7,6 +7,7 @@ public interface CustomUserPrincipal {
     String getNickname();
     String getRole();
     String getName();
+    String getOauthName();
     Map<String, Object> getAttributes();
 
 }

--- a/src/main/java/site/campingon/campingon/common/oauth/CustomOAuth2User.java
+++ b/src/main/java/site/campingon/campingon/common/oauth/CustomOAuth2User.java
@@ -62,6 +62,7 @@ public class CustomOAuth2User implements OAuth2User, CustomUserPrincipal {
         return OAuthUserDto.getEmail();
     }
 
+    @Override
     public String getOauthName(){
 
         return OAuthUserDto.getOauthName();

--- a/src/main/java/site/campingon/campingon/common/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/site/campingon/campingon/common/oauth/service/CustomOAuth2UserService.java
@@ -120,7 +120,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         try {
             restTemplate.exchange(url, HttpMethod.POST, null, String.class);
-            log.debug("Google account successfully revoked.");
+            log.debug("구글 연동 해제 완료");
 
             //DB 업데이트 - soft-delete, oauthName 삭제
             String oauthName = oauth2User.getOauthName();
@@ -131,7 +131,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .build();
             
             userRepository.save(updatedUser);
-            log.debug("User data successfully updated for deletion: {}", updatedUser);
 
         } catch (Exception e) {
             throw new OAuthException(ErrorCode.DELETE_USER_DENIED);

--- a/src/main/java/site/campingon/campingon/common/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/site/campingon/campingon/common/oauth/service/CustomOAuth2UserService.java
@@ -57,7 +57,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String oauthName = oAuth2ResponseDto.getProvider() + " " + oAuth2ResponseDto.getProviderId();
 
         // DB에 존재하는 oauth 로그인 계정인지 확인
-        User existUser = userRepository.findByOauthName(oauthName);
+        User existUser = userRepository.findByOauthNameAndDeletedAtIsNull(oauthName);
 
         // attributes에 accessToken 추가 -> oauth 연동 해제를 위해 토큰값이 필요
         Map<String, Object> newAttributes = new HashMap<>(oAuth2User.getAttributes());
@@ -124,10 +124,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             //DB 업데이트 - soft-delete, oauthName 삭제
             String oauthName = oauth2User.getOauthName();
-            User user = userRepository.findByOauthName(oauthName);
+            User user = userRepository.findByOauthNameAndDeletedAtIsNull(oauthName);
 
             User updatedUser = user.toBuilder()
-                    .oauthName(null)
                     .deletedAt(LocalDateTime.now())
                     .build();
             

--- a/src/main/java/site/campingon/campingon/user/controller/UserController.java
+++ b/src/main/java/site/campingon/campingon/user/controller/UserController.java
@@ -75,20 +75,15 @@ public class UserController {
     // 회원 탈퇴
     @DeleteMapping("/users/me")
     public ResponseEntity<Void> deleteUser(
-        @AuthenticationPrincipal CustomUserDetails userDetails,
-        @RequestBody String deleteReason,
-        Authentication authentication
+            @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal,
+            @RequestBody String deleteReason
     ) {
-        Long userId = userDetails.getId();
-
-        CustomUserPrincipal userPrincipal = (CustomUserPrincipal) authentication.getPrincipal();
-
-        // Google 유저인 경우
-        if (userPrincipal instanceof CustomOAuth2User oauthUser) {
+        // Google 유저인 경우와 일반 유저 분기 처리
+        if (customUserPrincipal instanceof CustomOAuth2User oauthUser) {
             customOAuth2UserService.deleteGoogleAccount(oauthUser);
+        } else if (customUserPrincipal instanceof CustomUserDetails customUserDetails) {
+            userService.deleteUser(customUserDetails.getId(), deleteReason);
         }
-
-        userService.deleteUser(userId, deleteReason);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/site/campingon/campingon/user/repository/UserRepository.java
+++ b/src/main/java/site/campingon/campingon/user/repository/UserRepository.java
@@ -17,7 +17,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndDeletedAtIsNull(String email);
 
     // user email로 중복유무 검색 - oauth 인증 절차
-    User findByOauthName(String oauthName);
+    User findByOauthNameAndDeletedAtIsNull(String oauthName);
 
     // 이메일 또는 닉네임 중복 여부 확인
     @Query("SELECT u FROM User u WHERE (u.email = :email OR u.nickname = :nickname) AND u.deletedAt IS NULL")


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

구글유저의 재가입 버그 해결

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] 구글유저와 일반유저 탈퇴 api 분기처리

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- 구글유저 탈퇴시 `oauthName` 삭제안함
- 대신 기존유저를 `OauthName과DeletedAt()`으로 로 체크
- 유저컨트롤러 탈퇴 api 수정

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.
구글유저 탈퇴 후 재로그인 시 새로운 데이터로 등록
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/43b6c0a6-911f-47e1-a10e-cf8b51cd3637">


## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #260 Closes #261