### PR TITLE
Fix/#279 캠핑장 id로 리뷰 페이지를 조회하는 기능 추가

### DIFF
--- a/src/main/java/site/campingon/campingon/camp/mapper/CampMapper.java
+++ b/src/main/java/site/campingon/campingon/camp/mapper/CampMapper.java
@@ -64,6 +64,7 @@ public interface CampMapper {
   @Mapping(target = "images", source = "images", qualifiedByName = "imagesToUrlList")
   @Mapping(target = "campAddr", source = "campAddr", qualifiedByName = "toCampAddrDto")
   @Mapping(target = "campInfo", source = "campInfo", qualifiedByName = "toCampInfoDto")
+  @Mapping(target = "animalAdmission", source = "animalAdmission")
   CampDetailResponseDto toCampDetailDto(Camp camp);
 
   @Named("toCampAddrDto")

--- a/src/main/java/site/campingon/campingon/review/controller/ReviewController.java
+++ b/src/main/java/site/campingon/campingon/review/controller/ReviewController.java
@@ -2,6 +2,10 @@ package site.campingon.campingon.review.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,7 +14,6 @@ import site.campingon.campingon.review.dto.ReviewResponseDto;
 import site.campingon.campingon.review.dto.ReviewUpdateRequestDto;
 import site.campingon.campingon.review.service.ReviewService;
 
-import java.util.List;
 
 @Slf4j
 @RestController
@@ -43,10 +46,11 @@ public class ReviewController {
 
     // 캠핑장 id로 리뷰 목록 조회
     @GetMapping("/{campId}/reviews")
-    public ResponseEntity<List<ReviewResponseDto>> getReviewsByCampId(
-            @PathVariable("campId") Long campId
+    public ResponseEntity<Page<ReviewResponseDto>> getReviewsByCampId(
+            @PathVariable("campId") Long campId,
+            @PageableDefault(size = 4, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        List<ReviewResponseDto> reviews = reviewService.getReviewsByCampId(campId);
+        Page<ReviewResponseDto> reviews = reviewService.getReviewsByCampId(campId, pageable);
         return ResponseEntity.ok(reviews);
     }
 

--- a/src/main/java/site/campingon/campingon/review/mapper/ReviewMapper.java
+++ b/src/main/java/site/campingon/campingon/review/mapper/ReviewMapper.java
@@ -46,8 +46,16 @@ public interface ReviewMapper {
     @Mapping(target = "content", source = "requestDto.content", defaultValue = "review.content")
     Review updateFromRequest(Review review, ReviewUpdateRequestDto requestDto);*/
 
-    List<ReviewResponseDto> toResponseDtoList(List<Review> reviews);
+//    List<ReviewResponseDto> toResponseDtoList(List<Review> reviews);
 
     @Mapping(target = "isRecommend", expression = "java(!review.isRecommend())")
     Review toUpdatedReview(Review review);
+
+    @Mapping(target = "reviewId", source = "id")
+    @Mapping(target = "campId", source = "camp.id")
+    @Mapping(target = "reservationId", source = "reservation.id")
+    @Mapping(target = "userId", source = "user.id")
+    @Mapping(target = "recommended", source = "recommend")
+    @Mapping(target = "images", expression = "java(review.getReviewImages() != null ? review.getReviewImages().stream().map(image -> image.getImageUrl()).toList() : java.util.List.of())")
+    ReviewResponseDto toDto(Review review);
 }

--- a/src/main/java/site/campingon/campingon/review/repository/ReviewRepository.java
+++ b/src/main/java/site/campingon/campingon/review/repository/ReviewRepository.java
@@ -1,5 +1,7 @@
 package site.campingon.campingon.review.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,7 +17,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByCampSiteId(Long campSiteId);
 
     // 특정 캠핑장 하위 모든 리뷰 조회
-    List<Review> findByCampId(Long campId);
+    Page<Review> findByCampId(Long campId, Pageable pageable);
 
     boolean existsByReservationId(Long reservationId);
 

--- a/src/main/java/site/campingon/campingon/review/service/ReviewService.java
+++ b/src/main/java/site/campingon/campingon/review/service/ReviewService.java
@@ -2,6 +2,8 @@ package site.campingon.campingon.review.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -187,12 +189,9 @@ public class ReviewService {
     }*/
 
     // 캠핑장 id로 리뷰 목록 조회
-    public List<ReviewResponseDto> getReviewsByCampId(Long campId) {
-        Camp camp = campRepository.findById(campId)
-                .orElseThrow(() -> new GlobalException(CAMP_NOT_FOUND_BY_ID));
-
-        List<Review> reviews = reviewRepository.findByCampId(camp.getId());
-        return reviewMapper.toResponseDtoList(reviews);
+    public Page<ReviewResponseDto> getReviewsByCampId(Long campId, Pageable pageable) {
+        Page<Review> reviews = reviewRepository.findByCampId(campId, pageable);
+        return reviews.map(reviewMapper::toDto);
     }
 
     // 리뷰 상세 조회


### PR DESCRIPTION
## 📌 목적
- 캠핑장 id로 리뷰 페이지를 조회하는 기능을 추가하기 위해

## 🛠️ 작업 상세 내용
- [x] 리뷰 컨트롤러 작성
- [x] 리뷰 서비스 작성
- [x] 리뷰 매퍼 작성
- [x] 리뷰 리파지토리 작성

## 🔍 변경 사항
- 이하동문

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타: