### PR TITLE
Refactor/#278 reservation 필요한 주소만 반환, 예약 조회 쿼리 수정

### DIFF
--- a/src/main/java/site/campingon/campingon/reservation/dto/CampAddrResponseDto.java
+++ b/src/main/java/site/campingon/campingon/reservation/dto/CampAddrResponseDto.java
@@ -9,14 +9,14 @@ import lombok.*;
 @AllArgsConstructor
 public class CampAddrResponseDto {
 
+    public String streetAddr;
+
+/*
+    // 유지보수를 고려해 주석 처리
     private String city;
-
     private String state;
-
     private String zipcode;
-
-    private String streetAddr;
-
     private String detailedAddr;
+*/
 
 }

--- a/src/main/java/site/campingon/campingon/reservation/dto/CampResponseDto.java
+++ b/src/main/java/site/campingon/campingon/reservation/dto/CampResponseDto.java
@@ -9,7 +9,7 @@ import lombok.*;
 @AllArgsConstructor
 public class CampResponseDto {
 
-    private Long id;
+    private Long campId;
 
     private String campName;
 

--- a/src/main/java/site/campingon/campingon/reservation/dto/CampSiteResponseDto.java
+++ b/src/main/java/site/campingon/campingon/reservation/dto/CampSiteResponseDto.java
@@ -10,7 +10,7 @@ import site.campingon.campingon.camp.entity.Induty;
 @AllArgsConstructor
 public class CampSiteResponseDto {
 
-    private Long id;
+    private Long siteId;
 
     private String indoorFacility;
 

--- a/src/main/java/site/campingon/campingon/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/site/campingon/campingon/reservation/mapper/ReservationMapper.java
@@ -26,9 +26,9 @@ public interface ReservationMapper {
 
     Reservation toEntity(ReservationCancelRequestDto reservationRequest);
 
-    @Mapping(source = "campSite", target = "campSiteResponseDto")
+    @Mapping(source = "campSite.id", target = "campSiteResponseDto.siteId")
     @Mapping(source = "camp.campAddr", target = "campAddrResponseDto")
-    @Mapping(source = "camp", target = "campResponseDto")
+    @Mapping(source = "camp.id", target = "campResponseDto.campId")
     @Mapping(source = "review", target = "reviewDto", qualifiedByName = "reviewToDto")
     ReservationResponseDto toResponse(Reservation reservation);
 

--- a/src/main/java/site/campingon/campingon/reservation/repository/ReservationRepository.java
+++ b/src/main/java/site/campingon/campingon/reservation/repository/ReservationRepository.java
@@ -15,7 +15,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     // 유저의 모든 예약 조회
     @EntityGraph(attributePaths = {"review"})
-    Page<Reservation> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    @Query("SELECT r FROM Reservation r WHERE r.user.id = :userId " +
+            "ORDER BY CASE " +
+            "WHEN r.status = 'RESERVED' THEN 0 " +
+            "WHEN r.status = 'COMPLETED' THEN 1 " +
+            "ELSE 2 END, r.checkinDate ASC")
+    Page<Reservation> findReservationsByUserId(Long userId, Pageable pageable);
 
     // 특정 예약의 상세 정보 조회 (연관된 캠프, 주소 정보 포함)
     @EntityGraph(attributePaths = {"camp", "campSite"})

--- a/src/main/java/site/campingon/campingon/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/site/campingon/campingon/reservation/service/ReservationServiceImpl.java
@@ -9,17 +9,11 @@ import site.campingon.campingon.camp.entity.Camp;
 import site.campingon.campingon.camp.entity.CampSite;
 import site.campingon.campingon.camp.mapper.CampSiteMapper;
 import site.campingon.campingon.reservation.dto.*;
-import site.campingon.campingon.reservation.entity.ReservationStatus;
 import site.campingon.campingon.reservation.repository.ReservationRepository;
 import site.campingon.campingon.reservation.mapper.ReservationMapper;
 import site.campingon.campingon.reservation.entity.Reservation;
 import site.campingon.campingon.reservation.utils.ReservationValidate;
 import site.campingon.campingon.user.entity.User;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +29,7 @@ public class ReservationServiceImpl implements ReservationService {
 
         reservationValidate.validateUserById(userId);
 
-        Page<Reservation> reservations = reservationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        Page<Reservation> reservations = reservationRepository.findReservationsByUserId(userId, pageable);
 
         return reservations.map(reservationMapper::toResponse);
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,6 +5,12 @@ spring:
         registration:
           google:
             redirect-uri: http://localhost:8080/login/oauth2/code/google
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 2000
+      password:
 
 app:
   front-url: http://localhost:3000

--- a/src/test/java/site/campingon/campingon/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/site/campingon/campingon/reservation/service/ReservationServiceTest.java
@@ -76,7 +76,6 @@ class ReservationServiceTest {
 
         mockReservation = Reservation.builder()
                 .id(1L)
-                .user(mockUser)
                 .camp(mockCamp)
                 .campSite(mockCampSite)
                 .checkinDate(LocalDate.from(LocalDateTime.now()))
@@ -87,23 +86,17 @@ class ReservationServiceTest {
                 .build();
 
         mockCampAddrDto = CampAddrResponseDto.builder()
-                .city("TestCity")
-                .state("TestState")
-                .zipcode("TestZipcode")
                 .streetAddr("Test Street")
-                .detailedAddr("Test detailedAddr")
                 .build();
 
         mockCampDto = CampResponseDto.builder()
-                .id(1L)
-                .name("Test Camp")
+                .campId(1L)
+                .campName("Test Camp")
                 .thumbImage("Test Image")
                 .build();
 
         mockReservationDto = ReservationResponseDto.builder()
                 .id(1L)
-                .userId(mockUser.getId())
-                .campSiteId(mockCampSite.getId())
                 .guestCnt(mockReservation.getGuestCnt())
                 .status(mockReservation.getStatus())
                 .totalPrice(mockReservation.getTotalPrice())
@@ -123,7 +116,7 @@ class ReservationServiceTest {
         List<Reservation> reservations = List.of(mockReservation);
         Page<Reservation> reservationPage = new PageImpl<>(reservations);
 
-        when(reservationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable))
+        when(reservationRepository.findReservationsByUserId(userId, pageable))
             .thenReturn(reservationPage);
         when(reservationMapper.toResponse(mockReservation))
             .thenReturn(mockReservationDto);
@@ -135,7 +128,7 @@ class ReservationServiceTest {
         assertNotNull(result);
         assertTrue(result.hasContent());
         assertEquals(mockReservationDto, result.getContent().get(0));
-        verify(reservationRepository).findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        verify(reservationRepository).findReservationsByUserId(userId, pageable);
     }
 
     @Test


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

reservation 필요한 주소만 반환, 예약 조회 쿼리 수정

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] 유저의 모든 예약 조회시 예약상태, 체크인날짜에 따른 우선순위 조정
- [x] response에 담긴 id 필드에 도메인 명시
- [x] 주소 반환 시 streetAddr만 남기고 주석처리

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- 유저의 모든예약 조회시 쿼리 수정
- 예약 response DTO 의 id 필드 변경
- `application-dev.yml`에 redis 설정추가

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

예약정보 조회하는 api 응답 반환시의 필드이름이 변경되었으니 FE쪽과 함께 MERGE해주세용
https://github.com/CampingOn/CampingOn-FE/pull/167

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #278
- https://github.com/CampingOn/CampingOn-FE/issues/161